### PR TITLE
Added build quick start documentation for new contributors and users

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -7,13 +7,29 @@ Also See [build-and-release.yml in nijigenerate](https://github.com/nijigenerate
 and [build-and-release.yml in nijiexpose](https://github.com/nijigenerate/nijiexpose/blob/main/.github/workflows/build-and-release.yml)
 
 ## Install Dependencies
-Ubuntu
+### Ubuntu
 ```bash
 sudo apt update
-sudo apt install ldc build-essential dub cmake git libsdl2-dev libfreetype6-dev
+sudo apt install build-essential dub cmake git libsdl2-dev libfreetype6-dev
 ```
 
-Archlinux
+For Ubuntu 24.04, install the compiler
+```
+sudo apt install ldc 
+```
+
+For Ubuntu 22.04 uses an older version of `ldc2`, you must install `dmd`
+```
+sudo apt install curl
+curl -fsS https://dlang.org/install.sh | bash -s dmd
+```
+
+Make sure you activate `dmd` environment before compiling, The installation script will provide a version hint when it is complete.
+```
+source ~/dlang/dmd-2.109.1/activate
+```
+
+### Archlinux
 ```bash
 sudo pacman -Syu
 sudo pacman -S ldc base-devel dub cmake git sdl2 freetype2
@@ -39,7 +55,7 @@ git clone https://github.com/Inochi2D/i2d-imgui
 dub add-local i2d-imgui 0.8.0
 ```
 
-On Debian/Ubuntu, a link error may occur. To fix the libz issue, use `vim ./nijigenerate/dub.sdl` to find this line:
+On Ubuntu 24.04 LTS, a link error may occur. To fix the libz issue, use `vim ./nijigenerate/dub.sdl` to find this line:
 ```
 lflags "-rpath=$$ORIGIN" platform="linux"
 ```
@@ -48,7 +64,7 @@ add `"-lz"` flag
 lflags "-rpath=$$ORIGIN" "-lz" platform="linux"
 ```
 
-build nijigenerate
+To build nijigenerate, if you use dmd, please replace `--compiler=ldc2` with `--compiler=dmd`
 ```
 cd nijigenerate
 dub build --config=meta

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,66 @@
+# Build How-to
+
+This is a quick start guide for building nijigenerate and nijiexpose. For users and developers,
+you can follow the instructions below to build on your Linux system.
+
+Also See [build-and-release.yml in nijigenerate](https://github.com/nijigenerate/nijigenerate/blob/main/.github/workflows/build-and-release.yml) 
+and [build-and-release.yml in nijiexpose](https://github.com/nijigenerate/nijiexpose/blob/main/.github/workflows/build-and-release.yml)
+
+## Install dependencies
+Ubuntu
+```bash
+sudo apt update
+sudo apt install ldc build-essential dub cmake git libsdl2-dev libfreetype6-dev
+```
+
+Archlinux
+```bash
+sudo pacman -Syu
+sudo pacman -S ldc base-devel dub cmake git sdl2 freetype2
+```
+
+## Build nijilive project
+First, we need to clone the four projects under nijigenerate and add them to `dub add-local`.
+```bash
+git clone https://github.com/nijigenerate/nijigenerate
+dub add-local ./nijigenerate 0.0.1
+git clone https://github.com/nijigenerate/nijilive
+dub add-local ./nijilive 0.0.1
+git clone https://github.com/nijigenerate/nijiui
+dub add-local ./nijiui 0.0.1 
+git clone https://github.com/nijigenerate/nijiexpose
+dub add-local ./nijiexpose 0.0.1
+```
+
+dub package `i2d-imgui` will use the `Master` branch by default when building SDL2,
+but the upstream branch has been changed to `main`. We need to fix it with the following instructions.
+```bash
+git clone https://github.com/Inochi2D/i2d-imgui
+dub add-local i2d-imgui 0.8.0
+```
+
+On Debian/Ubuntu, a link error may occur. To fix the libz issue, use `vim ./nijigenerate/dub.sdl` to find this line:
+```
+lflags "-rpath=$$ORIGIN" platform="linux"
+```
+add `"-lz"` flag
+```
+lflags "-rpath=$$ORIGIN" "-lz" platform="linux"
+```
+
+build nijigenerate
+```
+cd nijigenerate
+dub build --config=meta
+dub build --compiler=ldc2 --build=release --config=linux-full
+./out/nijigenerate
+```
+
+build nijiexpose
+```
+cd nijiexpose
+dub build --config=meta
+dub build --compiler=ldc2 --build=release --config=linux-full
+./out/nijiexpose
+```
+

--- a/BUILD.md
+++ b/BUILD.md
@@ -6,7 +6,7 @@ you can follow the instructions below to build on your Linux system.
 Also See [build-and-release.yml in nijigenerate](https://github.com/nijigenerate/nijigenerate/blob/main/.github/workflows/build-and-release.yml) 
 and [build-and-release.yml in nijiexpose](https://github.com/nijigenerate/nijiexpose/blob/main/.github/workflows/build-and-release.yml)
 
-## Install dependencies
+## Install Dependencies
 Ubuntu
 ```bash
 sudo apt update
@@ -19,7 +19,7 @@ sudo pacman -Syu
 sudo pacman -S ldc base-devel dub cmake git sdl2 freetype2
 ```
 
-## Build nijilive project
+## Build nijilive Project
 First, we need to clone the four projects under nijigenerate and add them to `dub add-local`.
 ```bash
 git clone https://github.com/nijigenerate/nijigenerate

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Links in `source/nijigenerate/config.d` should be updated to point to your packa
 &nbsp;
 
 ## Building
+We have a quick start guide [BUILD.md](./BUILD.md) to help users build nijigenerate. For new contributors and users, it is recommended to refer to this guide.
+
 It's occasionally the case that our dependencies are out of sync with dub, so it's somewhat recommended if you're building from source to clone the tip of `main` and `dub add-local . "<version matching nijigenerate dep>"` any of our forked dependencies (i18n-d, psd-d, bindbc-imgui, facetrack-d, inmath, nijilive). This will generally keep you up to date with what we're doing, and it's how the primary contributors work. Ideally we'd have a script to help set this up, but currently we do it manually, PRs welcome :)
 
 Because our project has dependencies on C++ through bindbc-imgui, and because there's no common way to get imgui binaries across platforms, we require a C++ toolchain as well as a few extra dependencies installed. These will be listed in their respective platform sections below.  


### PR DESCRIPTION
Hi, I have added a build guide, which has been tested on x86_64 Docker containers running both Ubuntu 22.04 and Arch Linux. This should help those interested in compiling or contributing to the project.
