### PR TITLE
Improve gitver experience

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -72,9 +72,6 @@ jobs:
 
     - name: 'Build nijigenerate'
       run: |
-        # Build metadata (like version information and icons)
-        dub build --config=meta
-
         # Build the project, with its main file included, without unittests
         dub build --compiler=ldc2 --build=release --config=linux-full
 
@@ -133,9 +130,6 @@ jobs:
         }
         Invoke-VSDevEnvironment
         
-        # Build metadata (like version information and icons)
-        dub build --config=meta
-
         # Build the project, with its main file included, without unittests
         dub build --compiler=ldc2 --build=release --config=win32-full
 
@@ -261,9 +255,6 @@ jobs:
       env:
         DFLAGS: "-force-dwarf-frame-section=false"
       run: |
-        # Build metadata (like version information and icons)
-        dub build --config=meta
-        
         # First build ARM64 version...
         echo "Building arm64 binary..."
         dub build --build=release --config=osx-full --arch=arm64-apple-macos

--- a/.github/workflows/build-demo.yml
+++ b/.github/workflows/build-demo.yml
@@ -71,9 +71,6 @@ jobs:
 
     - name: 'Build nijigenerate'
       run: |
-        # Build metadata (like version information and icons)
-        dub build --config=meta
-
         # Build the project, with its main file included, without unittests
         dub build --compiler=ldc2 --build=release --config=linux-full
 
@@ -128,9 +125,6 @@ jobs:
         }
         Invoke-VSDevEnvironment
         
-        # Build metadata (like version information and icons)
-        dub build --config=meta
-
         # Build the project, with its main file included, without unittests
         dub build --compiler=ldc2 --build=release --config=win32-full
 
@@ -229,9 +223,6 @@ jobs:
       env:
         DFLAGS: "-force-dwarf-frame-section=false"
       run: |
-        # Build metadata (like version information and icons)
-        dub build --config=meta
-        
         # First build ARM64 version...
         echo "Building arm64 binary..."
         dub build --build=release --config=osx-full --arch=arm64-apple-macos

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -70,9 +70,6 @@ jobs:
 
     - name: 'Build nijigenerate'
       run: |
-        # Build metadata (like version information and icons)
-        dub build --config=meta
-
         # Build the project, with its main file included, without unittests
         dub build --compiler=ldc2 --config=linux-nightly
           
@@ -130,9 +127,6 @@ jobs:
         }
         Invoke-VSDevEnvironment
         Remove-Item 'C:/Strawberry' -Recurse
-
-        # Build metadata (like version information and icons)
-        dub build --config=meta
 
         # Build the project, with its main file included, without unittests
         dub build --compiler=ldc2 --config=win32-nightly
@@ -223,9 +217,6 @@ jobs:
       env:
         DFLAGS: "-g -force-dwarf-frame-section=false"
       run: |
-
-        # Build metadata (like version information and icons)
-        dub build --config=meta
 
         # First build ARM64 version...
         echo "Building arm64 binary..."

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -35,9 +35,6 @@ jobs:
 
     - name: 'Build and Test'
       run: |
-        # Build metadata (like version information and icons)
-        dub build --config=meta
-        
         # Build the project, with its main file included, without unittests
         dub build --compiler=ldc2 --build=release --config=linux-full
 

--- a/build-aux/flatpak/nightly/nijigenerate.nijigenerate.yml
+++ b/build-aux/flatpak/nightly/nijigenerate.nijigenerate.yml
@@ -45,7 +45,6 @@ modules:
         dub add-local i2d-imgui/ "0.8.0";
         dub add-local nijilive/ "0.8.0";
         dub add-local dcv-i2d/ "0.3.0";
-        dub build --config=meta;
         dub build --config=linux-nightly --debug=InExperimental
       - install -m 755 ./out/nijigenerate /app/bin/nijigenerate
       - install -Dm644 ./out/*.mo /app/bin

--- a/build-aux/osx/BuildUniversal.sh
+++ b/build-aux/osx/BuildUniversal.sh
@@ -1,6 +1,3 @@
-# Generate version files...
-dub build --config=meta
-
 # First build ARM64 version...
 echo "Building arm64 binary..."
 dub build --build=release --config=osx-full --arch=arm64-apple-macos

--- a/dub.sdl
+++ b/dub.sdl
@@ -20,6 +20,8 @@ lflags "-rpath=$$ORIGIN" platform="linux"
 versions "GL_32" "USE_SDL2" "SDL_208" "UseUIScaling"
 stringImportPaths "res/" "./"
 
+preBuildCommands "sh update-gitver.sh nijigenerate INC"
+preBuildCommands "rc.exe /v build-aux\\windows\\nijigenerate.rc" platform="windows"
 
 // Barebones build
 configuration "barebones" {
@@ -28,13 +30,6 @@ configuration "barebones" {
 	targetType "executable"
 	subConfiguration "i2d-imgui" "static_dynamicCRT"
 	copyFiles "res/NotoSansCJK-Regular-LICENSE" "res/MaterialIcons-LICENSE" "res/OpenDyslexic-LICENSE" "LICENSE"
-}
-
-// Metadata generation
-configuration "meta" {
-	targetType "none"
-	preGenerateCommands "dub run -y gitver -- --prefix INC --file source/nijigenerate/ver.d --mod nijigenerate.ver --appname \"nijigenerate\" --itchfile version.txt"
-	preGenerateCommands "rc.exe /v build-aux\\windows\\nijigenerate.rc" platform="windows"
 }
 
 // Linux build

--- a/update-gitver.sh
+++ b/update-gitver.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+dub run gitver -- --prefix $2 --file source/$1/ver.d.new --mod $1.ver --appname $1
+cmp source/$1/ver.d source/$1/ver.d.new &>/dev/null && rm source/$1/ver.d.new && exit 0 || true
+mv -f source/$1/ver.d.new source/$1/ver.d


### PR DESCRIPTION
Do not use a separate "meta" config for metadata, since that makes it confusing to build the project for the first time. Just run gitver directly on build.

Also wrap it in a script that only replaces the version file if it changed. This avoids forcing a full source rebuild if nothing changed.