### PR TITLE
Fix/tool cursor rotate

### DIFF
--- a/source/nijigenerate/viewport/common/mesheditor/tools/select.d
+++ b/source/nijigenerate/viewport/common/mesheditor/tools/select.d
@@ -68,8 +68,6 @@ class NodeSelect : Tool, Draggable {
         float D_prime = D_0 - dot(n_prime, translation);
 
         // calculated transformed A', B', C', D'
-        debug writefln("T=%s, RS=%s, R=%s, S=%s, RS3.inv=%s, A=%f, B=%f, C=%f, D=%f", translation, RS, R, S, RS3.inverse, n_prime.x, n_prime.y, n_prime.z, D_prime);
-
         // assume mouse position is on the line define by fixed point (x, y, 0) and unit vector (0, 0, 1)
         vec3 point = vec3(mousePos.x, mousePos.y, 0);
         vec3 direction = vec3(0.0, 0.0, 1.0);
@@ -87,7 +85,6 @@ class NodeSelect : Tool, Draggable {
             projectionMousePos.y = float.nan;
         }
         impl.mousePos = projectionMousePos.xy;
-        debug writefln("mousePos=%s->%s", mousePos, projectionMousePos);
         return projectionMousePos;
     }
 
@@ -112,7 +109,6 @@ class NodeSelect : Tool, Draggable {
             vec4 pIn = vec4(calculateMousePosIntersection(impl, -impl.mousePos), 1);
             mat4 tr = impl.transform.inverse();
             vec4 pOut = tr * pIn;
-            debug writefln("NEW: mousePosScreen = %s", pOut);
             impl.mousePos = pOut.xy;
         } else {
             impl.mousePos = -impl.mousePos;

--- a/source/nijigenerate/viewport/common/mesheditor/tools/select.d
+++ b/source/nijigenerate/viewport/common/mesheditor/tools/select.d
@@ -44,31 +44,76 @@ class NodeSelect : Tool, Draggable {
         incViewportSetAlwaysUpdate(false);
     }
 
+    vec3 calculateMousePosIntersection(IncMeshEditorOne impl, vec2 mousePos) {
+        vec3 translation = vec3(impl.transform[0][3], impl.transform[1][3], impl.transform[2][3]);
+        mat4 RS = impl.transform;
+        RS[0][3] = RS[1][3] = RS[2][3] = 0;
+        float sx = vec3(RS[0][0], RS[1][0], RS[2][0]).length(); 
+        float sy = vec3(RS[0][1], RS[1][1], RS[2][1]).length(); 
+        float sz = vec3(RS[0][2], RS[1][2], RS[2][2]).length();
+        mat4 R = mat4(sx, 0, 0, 0, 
+                      0, sy, 0, 0, 
+                      0, 0, sz, 0, 
+                      0, 0, 0, 1);
+        mat4 S = RS * R.inverse;
+
+        // Assume that normal vector n of the mesh plane is defined as n = (0, 0, 1)
+        vec3 n = vec3(0.0, 0.0, 1.0);
+        float D_0 = 0.0;
+
+        // plane is represented as Ax + By + Cz + D = 0
+        // calculate transformed normal vector n' and D' 
+        mat3 RS3 = mat3(RS);
+        vec3 n_prime = (mat3(S) * mat3(R)).inverse.transposed * n;
+        float D_prime = D_0 - dot(n_prime, translation);
+
+        // calculated transformed A', B', C', D'
+        debug writefln("T=%s, RS=%s, R=%s, S=%s, RS3.inv=%s, A=%f, B=%f, C=%f, D=%f", translation, RS, R, S, RS3.inverse, n_prime.x, n_prime.y, n_prime.z, D_prime);
+
+        // assume mouse position is on the line define by fixed point (x, y, 0) and unit vector (0, 0, 1)
+        vec3 point = vec3(mousePos.x, mousePos.y, 0);
+        vec3 direction = vec3(0.0, 0.0, 1.0);
+
+        // calculated the intersection of line and plane.
+        float numerator = -(dot(n_prime.xy, point.xy) + D_prime);
+        float denominator = n_prime.z;
+
+        vec3 projectionMousePos;
+        if (denominator != 0.0) {
+            float t_intersection = numerator / denominator;
+            projectionMousePos = point + t_intersection * direction;
+        } else {
+            projectionMousePos.x = float.nan;
+            projectionMousePos.y = float.nan;
+        }
+        impl.mousePos = projectionMousePos.xy;
+        debug writefln("mousePos=%s->%s", mousePos, projectionMousePos);
+        return projectionMousePos;
+    }
+
     override 
     int peek(ImGuiIO* io, IncMeshEditorOne impl) {
         impl.lastMousePos = impl.mousePos;
 
         impl.mousePos = incInputGetMousePosition();
         if (impl.deformOnly) {
-            // Since `impl.mousePos` is on the mesh plane, we need to apply an inverse matrix
-            // to convert it back to the original coordinate system (screen).
-
-            /* as transform matrix would rotation of the x or y axis cause visual offset.
-             * z       C (mesh plane)
-             * ^      /|
-             *       / |
-             *     A/  |
-             *    /|\  |
-             *   / |  \|
-             * x/__|___|_______> y (Screen)
-             *    B    D
-             * We expected to use D to get C but instead we got A
+            /* impl.mousePos must be calculated as point C, but above code return point D.
+             * calculate the intersection point of plane and line DC first, and then calculate position in mesh coordinate.
+             * z      C (mesh plane)
+             * ^     /|
+             *      / |
+             *     /  |
+             *    /|  |
+             *   / |  |
+             * x/__|__|_______> y (Screen)
+             *    B   D
              */
 
-            vec4 pIn = vec4(-impl.mousePos.x, -impl.mousePos.y, 0, 1);
+            vec4 pIn = vec4(calculateMousePosIntersection(impl, -impl.mousePos), 1);
             mat4 tr = impl.transform.inverse();
             vec4 pOut = tr * pIn;
-           impl. mousePos = vec2(pOut.x, pOut.y);
+            debug writefln("NEW: mousePosScreen = %s", pOut);
+            impl.mousePos = pOut.xy;
         } else {
             impl.mousePos = -impl.mousePos;
         }


### PR DESCRIPTION
Cursor position is not calculated accurately when Part is rotated along X/Y axes.
This patch fixes the position calculation logic.