### PR TITLE
Generate debug artifacts for flatpak nightly release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -340,6 +340,7 @@ jobs:
         set -e
         mkdir -p ${FLATPAK_BUILD_REPO}/{extensions,refs/{mirrors,remotes},state,tmp/cache}
         flatpak build-bundle --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo ${FLATPAK_BUILD_REPO} ${FLATPAK_BUNDLE}.flatpak ${APP_ID} ${FLATPAK_BRANCH}
+        flatpak build-bundle --runtime ${FLATPAK_BUILD_REPO} ${FLATPAK_BUNDLE}.debug.flatpak ${APP_ID/-/_}.Debug ${FLATPAK_BRANCH}
 
     - name: Release to nightly tag
       uses: softprops/action-gh-release@v1
@@ -348,4 +349,5 @@ jobs:
         tag_name: nightly
         files: |
           ${{ env.FLATPAK_BUNDLE }}.flatpak
+          ${{ env.FLATPAK_BUNDLE }}.debug.flatpak
 


### PR DESCRIPTION
This PR adds the ability to generate debug artifacts for the bundled flatpak nightly release.

If both versions are installed, you can use [flatpak debugging capabilities](https://docs.flatpak.org/en/latest/debugging.html).

For example, if you run 
```sh
flatpak run --devel --command="gdb" io.github.nijigenerate.nijiexpose --ex "r" nijiexpose
```
you'll have the symbols available to debug the app through gdb.