### PR TITLE
Fixed Mirror View and Flip Pairings igButton Label Collision and Use Standard D Features

### DIFF
--- a/source/nijigenerate/panels/viewport.d
+++ b/source/nijigenerate/panels/viewport.d
@@ -313,7 +313,7 @@ protected:
         igSameLine();
 
         if (igBeginChild("##ModelControl", ImVec2(0, currSize.y), false, flags.NoScrollbar)) {
-            if (incButtonColored("", ImVec2(32, 0), incShouldMirrorViewport ? ImVec4.init : ImVec4(0.6f, 0.6f, 0.6f, 1f))) {
+            if (incButtonColored("##MirrorView", ImVec2(32, 0), incShouldMirrorViewport ? ImVec4.init : ImVec4(0.6f, 0.6f, 0.6f, 1f))) {
                 if (incActivePuppet() !is null)
                     incShouldMirrorViewport = !incShouldMirrorViewport;
             }

--- a/source/nijigenerate/viewport/package.d
+++ b/source/nijigenerate/viewport/package.d
@@ -140,9 +140,7 @@ float incGetMirrorX2(float x) {
 }
 
 void incMirrorIO(ImGuiIO *result) {
-    ImGuiIO* io = igGetIO();
-    import core.stdc.string : memcpy;
-    memcpy(result, io, ImGuiIO.sizeof);
+    *result = *igGetIO();
 
     if (incShouldMirrorViewport)
         result.MousePos.x = incGetMirrorX(result.MousePos.x);


### PR DESCRIPTION
Fixed the issue where the "Mirror View" and "Flip Pairings" labels were the same, causing "Flip Pairings" to not work.
https://github.com/ocornut/imgui/blob/master/docs/FAQ.md#q-how-can-i-have-multiple-windows-with-the-same-label

Use standard D features instead of memcpy