### PR TITLE
Fixed animation create crash when import PSD or KRA

### DIFF
--- a/source/nijigenerate/io/kra.d
+++ b/source/nijigenerate/io/kra.d
@@ -237,6 +237,8 @@ void incImportKRA(string file, IncKRAImportSettings settings = IncKRAImportSetti
         incActiveProject().puppet = puppet;
         incFocusCamera(incActivePuppet().root);
 
+        incInitAnimationPlayer(puppet);
+
         incSetStatus(_("%s was imported...".format(file)));
     } catch (Exception ex) {
 

--- a/source/nijigenerate/io/psd.d
+++ b/source/nijigenerate/io/psd.d
@@ -238,6 +238,8 @@ void incImportPSD(string file, IncPSDImportSettings settings = IncPSDImportSetti
         incActiveProject().puppet = puppet;
         incFocusCamera(incActivePuppet().root);
 
+        incInitAnimationPlayer(puppet);
+
         incSetStatus(_("%s was imported...".format(file)));
     } catch (Exception ex) {
 

--- a/source/nijigenerate/package.d
+++ b/source/nijigenerate/package.d
@@ -159,6 +159,11 @@ void incAddPrevProject(string path) {
     incSettingsSave();
 }
 
+void incInitAnimationPlayer(Puppet puppet) {
+    incAnimationPlayer = new AnimationPlayer(activeProject.puppet);
+    incAnimationCurrent = null;
+}
+
 /**
     Creates a new project
 */
@@ -177,8 +182,7 @@ void incNewProject() {
 
     activeProject = new Project;
     activeProject.puppet = new ExPuppet;
-    incAnimationPlayer = new AnimationPlayer(activeProject.puppet);
-    incAnimationCurrent = null;
+    incInitAnimationPlayer(activeProject.puppet);
     incFocusCamera(activeProject.puppet.root);
     incSelectNode(null);
     incDisarmParameter();
@@ -258,8 +262,7 @@ void incOpenProject(bool handleError=true)(string mainPath, string backupPath) {
     incFocusCamera(incActivePuppet().root);
     incFreeMemory();
 
-    incAnimationPlayer = new AnimationPlayer(puppet);
-    incAnimationCurrent = null;
+    incInitAnimationPlayer(puppet);
 
     incSetStatus(_("%s opened successfully.").format(currProjectPath));
     incSetWindowTitle(currProjectPath.baseName);
@@ -335,8 +338,7 @@ void incImportFolder(string folder) {
     puppet.rescanNodes();
     puppet.populateTextureSlots();
     incActiveProject().puppet = puppet;
-    incAnimationPlayer = new AnimationPlayer(puppet);
-    incAnimationCurrent = null;
+    incInitAnimationPlayer(puppet);
     incFocusCamera(incActivePuppet().root);
     incFreeMemory();
 


### PR DESCRIPTION
Fixed bug reported by yussuna

Reproduced by Grillo
1. import psd
2. open animation panel
3. create new animation


Initialize animation after psd/kra imported