### PR TITLE
Add SizeSort for Viewport Right Click Menu Sorting

### DIFF
--- a/source/nijigenerate/viewport/model/package.d
+++ b/source/nijigenerate/viewport/model/package.d
@@ -28,6 +28,19 @@ private {
     enum ENTRY_SIZE = 48;
 }
 
+enum ViewporMenuSortMode {
+    ZSort,
+    SizeSort,
+}
+
+/** 
+    Default to SizeSort because when selecting objects, especially detailed puppets 
+    or small components, we assume the user will point directly at the one they want. 
+    Prioritizing smaller objects makes them easier to select, while larger objects 
+    can usually be selected by clicking elsewhere if needed.
+*/
+ViewporMenuSortMode incViewportModelMenuSortMode = ViewporMenuSortMode.SizeSort;
+
 void incViewportModelMenuOpening() {
     foundParts.length = 0;
 
@@ -47,9 +60,20 @@ void incViewportModelMenuOpening() {
     import std.algorithm.sorting : sort;
     import std.algorithm.mutation : SwapStrategy;
     import std.math : cmp;
-    sort!((a, b) => cmp(
-        a.zSortNoOffset, 
-        b.zSortNoOffset) < 0, SwapStrategy.stable)(foundParts);
+
+    if (incViewportModelMenuSortMode == ViewporMenuSortMode.ZSort) {
+        sort!((a, b) => cmp(
+            a.zSortNoOffset, 
+            b.zSortNoOffset) < 0, SwapStrategy.stable)(foundParts);
+
+    } else if (incViewportModelMenuSortMode == ViewporMenuSortMode.SizeSort) {
+        sort!((a, b) => cmp(
+            (a.bounds.z - a.bounds.x) * (a.bounds.w - a.bounds.y), 
+            (b.bounds.z - b.bounds.x) * (b.bounds.w - b.bounds.y)) < 0, SwapStrategy.stable)(foundParts);
+
+    } else {
+        throw new Exception("Unknown sort mode");
+    }
 }
 
 void incViewportModelMenu() {

--- a/source/nijigenerate/viewport/model/package.d
+++ b/source/nijigenerate/viewport/model/package.d
@@ -80,7 +80,14 @@ void incViewportModelMenu() {
     if (auto editor = incViewportModelDeformGetEditor()) {
         editor.popupMenu();
     }
-    igNewLine();
+
+    if (igMenuItem(incViewportModelMenuSortMode == ViewporMenuSortMode.ZSort ? __("Z-Sort") : __("Size-Sort"))) {
+        if (incViewportModelMenuSortMode == ViewporMenuSortMode.ZSort)
+            incViewportModelMenuSortMode = ViewporMenuSortMode.SizeSort;
+        else
+            incViewportModelMenuSortMode = ViewporMenuSortMode.ZSort;
+    }
+
     igSeparator();
     
     if (incSelectedNode() != incActivePuppet().root) {

--- a/source/nijigenerate/viewport/model/package.d
+++ b/source/nijigenerate/viewport/model/package.d
@@ -28,18 +28,17 @@ private {
     enum ENTRY_SIZE = 48;
 }
 
+/** 
+    For detailed puppets or small components, we assume the user will directly point to the one they want. 
+    ZSort is slightly less effective than SizeSort on layers with more alpha pixels (e.g., hair overlapping eyes). 
+    SizeSort prioritizes smaller objects, making them easier to select.
+*/
 enum ViewporMenuSortMode {
     ZSort,
     SizeSort,
 }
 
-/** 
-    Default to SizeSort because when selecting objects, especially detailed puppets 
-    or small components, we assume the user will point directly at the one they want. 
-    Prioritizing smaller objects makes them easier to select, while larger objects 
-    can usually be selected by clicking elsewhere if needed.
-*/
-ViewporMenuSortMode incViewportModelMenuSortMode = ViewporMenuSortMode.SizeSort;
+ViewporMenuSortMode incViewportModelMenuSortMode = ViewporMenuSortMode.ZSort;
 
 void incViewportModelMenuOpening() {
     foundParts.length = 0;


### PR DESCRIPTION
## Summary
This PR introduces a new sorting method based on object size and sets it as the default sorting mode in the viewport right-click menu.

## Details
- **Default Behavior**: Updated the default sorting mode to `SizeSort` to enhance the selection of smaller, detailed objects
- **Heuristic**: Prioritizing smaller objects makes it easier for users to select intricate items they are pointing at, while larger objects can still be selected by clicking elsewhere if needed.
- **Comparison**: 
  - Z sorting may produce unreliable results when objects contain a lot of alpha pixels.
  - Other solutions that use pixel or mesh-based intersection calculations can reduce performance and increase complexity. The `SizeSort` approach avoids these issues, offering a simpler alternative.
  - Combining `SizeSort` and `ZSort` to produce a composite sorting value is a potential enhancement. We can explore automatically adjusting to the optimal solution based on user feedback to further improve sorting accuracy and user experience.

## Benefits

- Enhanced usability when dealing with detailed or small components. 
- More intuitive selection process for users. 

## Demo
Zsort
<img width="429" alt="image" src="https://github.com/user-attachments/assets/f5e0f950-6f61-4670-b3d7-3ebc57179a4b">
size sort
<img width="458" alt="image" src="https://github.com/user-attachments/assets/32a8b26f-bb09-4f80-a813-ff7b7da52ff7">
Click the first item to toggle (zsort)
<img width="313" alt="image" src="https://github.com/user-attachments/assets/add04760-b345-4d5a-bd08-e92d63e31b57">
