### PR TITLE
Avoid crashes when opening files that do not exist

### DIFF
--- a/source/nijigenerate/package.d
+++ b/source/nijigenerate/package.d
@@ -227,6 +227,12 @@ void incOpenProject(bool handleError=true)(string path) {
 */
 void incOpenProject(bool handleError=true)(string mainPath, string backupPath) {
     import std.path : setExtension, baseName;
+    import std.file : exists;
+
+    // We should check if the file exists to prevent user confusion in case of a crash.
+    if (!exists(mainPath) && !exists(backupPath))
+        return incDialog(__("Error"), mainPath ~ _(" File does not exist."));
+
     incClearImguiData();
     
     Puppet puppet;

--- a/source/nijigenerate/package.d
+++ b/source/nijigenerate/package.d
@@ -208,51 +208,47 @@ void incResetRootNode(ref Puppet puppet) {
     puppet.root.localTransform.scale = vec2(1, 1);
 }
 
-void incOpenProject(bool handleError=true)(string path) {
+bool incOpenProject(string path) {
     if (incCheckLockfile(path)) {
         incPushWindow(new RestoreSaveWindow(path));
 
         //Answering that window is the new trigger for loading the project.
-        return;
+        return false;
     }
 
     // Usual case
-    incOpenProject!(handleError)(path, "");
+    return incOpenProject(path, "");
 }
 
 /**
     mainPath is the canonical project path that the user normally saves to.
     backupPath is the inx file to load all the data from, but is empty string
     when just loading a normal mainsave project file.
-*/
-void incOpenProject(bool handleError=true)(string mainPath, string backupPath) {
-    import std.path : setExtension, baseName;
-    import std.file : exists;
 
-    // We should check if the file exists to prevent user confusion in case of a crash.
-    if (!exists(mainPath) && !exists(backupPath))
-        return incDialog(__("Error"), mainPath ~ _(" File does not exist."));
+    Note: You should not write try-catch blocks when calling this function, as it
+        handles FileException internally. Adding try-catch blocks would make debugging more difficult.
+*/
+bool incOpenProject(string mainPath, string backupPath) {
+    import std.path : setExtension, baseName;
+    import std.file : FileException;
 
     incClearImguiData();
     
     Puppet puppet;
 
     // Load the puppet from file
-//    try {
+    try {
         if (backupPath.length > 0) {
             puppet = inLoadPuppet!ExPuppet(backupPath);
         } else {
             puppet = inLoadPuppet!ExPuppet(mainPath);
         }
-/*    } catch (Exception ex) {
-        static if (handleError) {
-            incDialog(__("Error"), ex.msg);
-            return;
-        } else {
-            throw ex;
-        }
+    } catch (FileException ex) {
+        // Also handle NFS or I/O errors
+        incDialog(__("Error"), ex.msg);
+        return false;
     }
-*/
+
     // Clear out stuff by creating a new project
     incNewProject();
 
@@ -272,6 +268,8 @@ void incOpenProject(bool handleError=true)(string mainPath, string backupPath) {
 
     incSetStatus(_("%s opened successfully.").format(currProjectPath));
     incSetWindowTitle(currProjectPath.baseName);
+
+    return true;
 }
 
 void incSaveProject(string path, string autosaveStamp = "") {

--- a/source/nijigenerate/windows/welcome.d
+++ b/source/nijigenerate/windows/welcome.d
@@ -12,6 +12,7 @@ import nijigenerate.windows;
 import nijigenerate.core;
 import nijigenerate.core.i18n;
 import std.string;
+import std.file : FileException;
 import nijigenerate.utils.link;
 import i18n;
 import nijilive;
@@ -226,12 +227,9 @@ protected:
 
                                 string file = incShowOpenDialog(filters, _("Open..."));
                                 if (file) {
-                                    try {
-                                        incOpenProject!false(file);
+                                    // FileException should handle in incOpenProject, so we don't write try/catch here
+                                    if (incOpenProject(file))
                                         this.close();
-                                    } catch(Exception ex) {
-                                        incDialog(__("Error"), ex.msg);
-                                    }
                                 }
                             }
 
@@ -268,12 +266,9 @@ protected:
 
                                     import std.path : baseName;
                                     if (incTextLinkWithIcon("", recent.baseName)) {
-                                        try {
-                                            incOpenProject!false(recent);
+                                        // FileException should handle in incOpenProject, so we don't write try/catch here
+                                        if (incOpenProject(recent))
                                             this.close();
-                                        } catch(Exception ex) {
-                                            incDialog(__("Error"), ex.msg);
-                                        }
                                     }
                                 }
                             } else {


### PR DESCRIPTION
Currently, the file history will not be updated after the file is deleted. Users may crash when opening files that do not exist. The patch adds a check.
```
std.file.FileException@std/file.d(372): /Users/user/notexistfile.inx: No such file or directory
----------------
??:? object.Throwable.TraceInfo core.runtime.defaultTraceHandler(void*) [0xxxxxxxxxx]
/Users/user/nijilive/source/nijilive/fmt/package.d:36 nijigenerate.ext.ExPuppet nijilive.fmt.inLoadPuppet!(nijigenerate.ext.ExPuppet).inLoadPuppet(immutable(char)[]) [0xxxxxxxxxx]
/Users/user/nijigenerate/source/nijigenerate/package.d:239 void nijigenerate.incOpenProject!(true).incOpenProject(immutable(char)[], immutable(char)[]) [0xxxxxxxxxx]
/Users/user/nijigenerate/source/nijigenerate/package.d:220 void nijigenerate.incOpenProject!(true).incOpenProject(immutable(char)[]) [0xxxxxxxxxx]
/Users/user/nijigenerate/source/nijigenerate/widgets/mainmenu.d:134 void nijigenerate.widgets.mainmenu.incMainMenu() [0xxxxxxxxxx]
/Users/user/nijigenerate/source/app.d:137 void app.incUpdate() [0xxxxxxxxxx]
/Users/user/nijigenerate/source/app.d:103 _Dmain [0xxxxxxxxxx]
```