### PR TITLE
fix: Freezing issue with nagscreen and popups

### DIFF
--- a/source/nijigenerate/core/package.d
+++ b/source/nijigenerate/core/package.d
@@ -704,8 +704,12 @@ void incBeginLoopNoEv() {
     // HACK: ImGui Crashes if a popup is rendered on the first frame, let's avoid that.
     if (firstFrame) firstFrame = false;
     else {
-        incModalRender();
-        incRenderDialogs();
+        // imgui can not igOpenPopup two popups at the same time, that causes a freeze
+        // so we sperate the popups rendering
+        if (incModalIsOpen())
+            incModalRender();
+        else
+            incRenderDialogs();
     }
 
     incHandleDialogHandlers();

--- a/source/nijigenerate/widgets/modal/package.d
+++ b/source/nijigenerate/widgets/modal/package.d
@@ -97,6 +97,12 @@ void incModalRender() {
         incModalList[incModalIndex].update();
     }
 }
+/** 
+    incModalIsOpen returns true if a modal is open
+*/
+bool incModalIsOpen() {
+    return incModalIndex > -1;
+}
 
 /**
     Adds a modal to the modal display list.


### PR DESCRIPTION
upstream PR: https://github.com/Inochi2D/inochi-creator/pull/396

* Separate rendering of popups in `incBeginLoopNoEv()`

https://github.com/ocornut/imgui/issues/2398

This commit separates the rendering of popups in the `incBeginLoopNoEv()` function to prevent freezing caused by attempting to render multiple popups simultaneously.