### PR TITLE
Restore Catch Exception Logic

### DIFF
--- a/source/nijigenerate/package.d
+++ b/source/nijigenerate/package.d
@@ -249,6 +249,16 @@ bool incOpenProject(string mainPath, string backupPath) {
         // Also handle NFS or I/O errors
         incDialog(__("Error"), ex.msg);
         return false;
+    } catch (Exception ex) {
+        // for user, we should show a dialog and dump the thrown stack
+        import std.file : write;
+        import nijigenerate.utils.crashdump;
+        string path = genCrashDumpPath("nijigenerate-runtime-error");
+        write(path, genCrashDump(ex));
+
+        // show dialog
+        incDialog(__("Error"), ex.msg ~ "\n\n" ~ _("Please report this file to the developers:\n\n%s").format(path));
+        return false;
     }
 
     // Clear out stuff by creating a new project

--- a/source/nijigenerate/utils/crashdump.d
+++ b/source/nijigenerate/utils/crashdump.d
@@ -54,12 +54,15 @@ string getCrashDumpDir() {
     else return expandTilde("~");
 }
 
-
+string genCrashDumpPath(string filename) {
+    import std.datetime;
+    return buildPath(getCrashDumpDir(), filename ~ "-" ~ Clock.currTime.toISOString() ~ ".txt");
+}
 
 void crashdump(T...)(Throwable throwable, T state) {
 
     // Write crash dump to disk
-    write(buildPath(getCrashDumpDir(), "nijigenerate-crashdump.txt"), genCrashDump!T(throwable, state));
+    write(genCrashDumpPath("nijigenerate-crashdump"), genCrashDump!T(throwable, state));
 
     // Use appropriate system method to notify user where crash dump is.
     version(OSX) writeln(_("\n\n\n===   nijigenerate has crashed   ===\nPlease send us the nijigenerate-crashdump.txt file in ~/Library/Logs\nAttach the file as a git issue @ https://github.com/nijigenerate/nijigenerate/issues"));


### PR DESCRIPTION
upstream PR: https://github.com/Inochi2D/inochi-creator/pull/424
upstream PR: https://github.com/Inochi2D/inochi-creator/pull/425

In any case, we should not crash at the user end
This commit reverts the previous FileException only error handling And add runtime error dump to let users know that they should report to developers