### PR TITLE
[BUG] Avoid crashes caused by non-existent crashdump path

### DIFF
--- a/source/nijigenerate/package.d
+++ b/source/nijigenerate/package.d
@@ -253,11 +253,17 @@ bool incOpenProject(string mainPath, string backupPath) {
         // for user, we should show a dialog and dump the thrown stack
         import std.file : write;
         import nijigenerate.utils.crashdump;
-        string path = genCrashDumpPath("nijigenerate-runtime-error");
-        write(path, genCrashDump(ex));
+        string report;
 
-        // show dialog
-        incDialog(__("Error"), ex.msg ~ "\n\n" ~ _("Please report this file to the developers:\n\n%s").format(path));
+        try {
+            string path = genCrashDumpPath("nijigenerate-runtime-error");
+            write(path, genCrashDump(ex));
+            report = _("Please report this file to the developers:\n\n%s").format(path);
+        } catch (Exception dumpEx) {
+            report = _("Failed to write crash dump file." ~ dumpEx.msg);
+        }
+
+        incDialog(__("Error"), ex.msg ~ "\n\n" ~ report);
         return false;
     }
 

--- a/source/nijigenerate/package.d
+++ b/source/nijigenerate/package.d
@@ -256,9 +256,7 @@ bool incOpenProject(string mainPath, string backupPath) {
         string report;
 
         try {
-            mkdirCrashDumpDir();
-            string path = genCrashDumpPath("nijigenerate-runtime-error");
-            write(path, genCrashDump(ex));
+            string path = writeCrashDump("nijigenerate-runtime-error", ex);
             report = _("Please report this file to the developers:\n\n%s").format(path);
         } catch (Exception dumpEx) {
             report = _("Failed to write crash dump file." ~ dumpEx.msg);

--- a/source/nijigenerate/package.d
+++ b/source/nijigenerate/package.d
@@ -256,6 +256,7 @@ bool incOpenProject(string mainPath, string backupPath) {
         string report;
 
         try {
+            mkdirCrashDumpDir();
             string path = genCrashDumpPath("nijigenerate-runtime-error");
             write(path, genCrashDump(ex));
             report = _("Please report this file to the developers:\n\n%s").format(path);

--- a/source/nijigenerate/utils/crashdump.d
+++ b/source/nijigenerate/utils/crashdump.d
@@ -10,6 +10,7 @@ import std.file : write;
 //import i18n;
 import std.stdio;
 import std.path;
+import std.process : environment;
 import std.traits;
 import std.array;
 import i18n;
@@ -47,10 +48,15 @@ version(Windows) {
     }
 }
 
+string linuxStateHome() {
+    // https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables
+    return environment.get("XDG_STATE_HOME", buildPath(environment["HOME"], ".local", "state"));
+}
+
 string getCrashDumpDir() {
     version(Windows) return getDesktopDir();
     else version(OSX) return expandTilde("~/Library/Logs/");
-    else version(linux) return expandTilde("$XDG_STATE_HOME/"); // https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables
+    else version(linux) return expandTilde(linuxStateHome() ~ "/");
     else return expandTilde("~");
 }
 
@@ -59,9 +65,26 @@ string genCrashDumpPath(string filename) {
     return buildPath(getCrashDumpDir(), filename ~ "-" ~ Clock.currTime.toISOString() ~ ".txt");
 }
 
+void mkdirCrashDumpDir() {
+    import std.file : mkdir, exists, setAttributes;
+    auto dir = getCrashDumpDir();
+    if (exists(dir))
+        return;
+    
+    // Should we set recursively make the directory or not?
+    mkdir(dir);
+    version(linux) {
+        import std.conv : octal;
+        // https://specifications.freedesktop.org/basedir-spec/latest/#referencing
+        // TODO: Should we set permissions recursively?
+        setAttributes(dir, octal!700);
+    }
+}
+
 void crashdump(T...)(Throwable throwable, T state) {
     // Write crash dump to disk
     try {
+        mkdirCrashDumpDir();
         write(genCrashDumpPath("nijigenerate-crashdump"), genCrashDump(throwable, state));
     } catch (Exception ex) {
         writeln("Failed to write crash dump" ~ ex.msg);

--- a/source/nijigenerate/utils/crashdump.d
+++ b/source/nijigenerate/utils/crashdump.d
@@ -81,11 +81,17 @@ void mkdirCrashDumpDir() {
     }
 }
 
+string writeCrashDump(T...)(string filename, Throwable throwable, T state) {
+    mkdirCrashDumpDir();
+    string path = genCrashDumpPath(filename);
+    write(path, genCrashDump(throwable, state));
+    return path;
+}
+
 void crashdump(T...)(Throwable throwable, T state) {
     // Write crash dump to disk
     try {
-        mkdirCrashDumpDir();
-        write(genCrashDumpPath("nijigenerate-crashdump"), genCrashDump(throwable, state));
+        writeCrashDump("nijigenerate-crashdump", throwable, state);
     } catch (Exception ex) {
         writeln("Failed to write crash dump" ~ ex.msg);
     }

--- a/source/nijigenerate/utils/crashdump.d
+++ b/source/nijigenerate/utils/crashdump.d
@@ -60,9 +60,12 @@ string genCrashDumpPath(string filename) {
 }
 
 void crashdump(T...)(Throwable throwable, T state) {
-
     // Write crash dump to disk
-    write(genCrashDumpPath("nijigenerate-crashdump"), genCrashDump!T(throwable, state));
+    try {
+        write(genCrashDumpPath("nijigenerate-crashdump"), genCrashDump(throwable, state));
+    } catch (Exception ex) {
+        writeln("Failed to write crash dump" ~ ex.msg);
+    }
 
     // Use appropriate system method to notify user where crash dump is.
     version(OSX) writeln(_("\n\n\n===   nijigenerate has crashed   ===\nPlease send us the nijigenerate-crashdump.txt file in ~/Library/Logs\nAttach the file as a git issue @ https://github.com/nijigenerate/nijigenerate/issues"));


### PR DESCRIPTION
upstream pr: https://github.com/Inochi2D/inochi-creator/pull/428

Currently writing crash dump, if the path does not exist will cause a crash.

so writing crash dump should in try catch block and handle XDG_STATE_HOME