### PR TITLE
Resource panel remembers layout status in .inx file.

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -11,6 +11,7 @@ import nijigenerate.core;
 import nijigenerate.core.settings;
 import nijigenerate.utils.crashdump;
 import nijigenerate.panels;
+import nijigenerate.panels.resource;
 import nijigenerate.windows;
 import nijigenerate.widgets;
 import nijigenerate.core.actionstack;
@@ -72,6 +73,8 @@ int main(string[] args)
         incInitExt();
 
         incInitFlipConfig();
+
+        ngInitResourcePanel();
 
         // Initialize video exporting
         incInitVideoExport();

--- a/source/nijigenerate/panels/resource.d
+++ b/source/nijigenerate/panels/resource.d
@@ -67,14 +67,23 @@ class ResourcePanelConfig : ISerializable {
         if (output) {
             auto state = serializer.objectBegin();
                 serializer.putKey("nextInHorizontal");
-                auto arr = serializer.arrayBegin();
+                auto arr1 = serializer.arrayBegin();
                     foreach(uuid; output.layout.keys()) {
                         if (output.layout[uuid].nextInHorizontal) {
                             serializer.elemBegin;
                             serializer.serializeValue(uuid);
                         }
                     }
-                serializer.arrayEnd(arr);
+                serializer.arrayEnd(arr1);
+                serializer.putKey("folded");
+                auto arr2 = serializer.arrayBegin();
+                    foreach(uuid; output.layout.keys()) {
+                        if (output.layout[uuid].folded) {
+                            serializer.elemBegin;
+                            serializer.serializeValue(uuid);
+                        }
+                    }
+                serializer.arrayEnd(arr2);
             serializer.objectEnd(state);
         }
     }
@@ -90,13 +99,26 @@ class ResourcePanelConfig : ISerializable {
         auto view = singleton.history[0];
         auto output = cast(IconTreeOutput)view.output;
 
-        auto elements = data["nextInHorizontal"].byElement;
-        while(!elements.empty) {
-            uint uuid;
-            elements.front.deserializeValue(uuid);
-            elements.popFront;
-            output.layout.require(uuid);
-            output.layout[uuid].nextInHorizontal = true;
+        if (!data["nextInHorizontal"].isEmpty) {
+            auto elements = data["nextInHorizontal"].byElement;
+            while(!elements.empty) {
+                uint uuid;
+                elements.front.deserializeValue(uuid);
+                elements.popFront;
+                output.layout.require(uuid);
+                output.layout[uuid].nextInHorizontal = true;
+            }
+        }
+
+        if (!data["folded"].isEmpty) {
+            auto elements = data["folded"].byElement;
+            while(!elements.empty) {
+                uint uuid;
+                elements.front.deserializeValue(uuid);
+                elements.popFront;
+                output.layout.require(uuid);
+                output.layout[uuid].folded = true;
+            }
         }
 
         return null;


### PR DESCRIPTION
Resource panel can change layout of parameters in several ways. This patch stores the current layout status into .inx file.

1) layout of next children.
  if any Node is double clicked, sibling node is shown in horizontal direction. this mode can be toggled. So when double clicking again, position is restored to vertical direction.

2) folding status.
  if arrows shown in left side is clicked, children are folded and hidden. this can be also toggled.