### PR TITLE
Bug fix: "Convert to" doesn't work correctly.

### DIFF
--- a/source/nijigenerate/panels/nodes.d
+++ b/source/nijigenerate/panels/nodes.d
@@ -256,7 +256,7 @@ void incNodeActionsPopup(const char* title, bool isRoot = false, bool icon = fal
                         igSameLine(0, 2);
                         if (igMenuItem(__(type), "", false, true)) {
                             Node node = inInstantiateNode(type);
-                            node.copyFrom(n, true, true);
+                            node.copyFrom(n, true, false);
                             incActionPush(new NodeReplaceAction(n, node, true));
                             node.notifyChange(node, NotifyReason.StructureChanged);
                         }


### PR DESCRIPTION
"Convert to" sometimes failed to alter Node with other types.
This is caused because of inappropriate handling of "inPlace" parameter in copyFrom method in Node object.
Now, "inPlace" parameter is changed to "clone" parameter, and stop to alter original node automatically.
When "clone" parameter is set, "uuid" becomes same as original Node.

With this patch, stability of "Convert to" command improved.