### PR TITLE
Automesh: Using Fiber to enable cancellation of the task easily.

### DIFF
--- a/source/nijigenerate/core/cv/contours.d
+++ b/source/nijigenerate/core/cv/contours.d
@@ -10,6 +10,7 @@ import std.math;
 import std.algorithm;
 import mir.rc.array;    // mir.rc.array を利用
 import inmath;         // vec2i は inmath モジュールに存在する
+import core.thread.fiber;
 
 /****************************************************
  * D言語による OpenCV cv::findContours に等価な実装（改善版）
@@ -377,6 +378,7 @@ void findContours(T)(in T binaryImage, out vec2i[][] contours, out ContourHierar
                     labels[y][x] = -1;
                 }
             }
+            Fiber.yield;
         }
     }
     

--- a/source/nijigenerate/core/math/path.d
+++ b/source/nijigenerate/core/math/path.d
@@ -3,6 +3,7 @@ module nijigenerate.core.math.path;
 import inmath;
 import mir.ndslice;
 import std.algorithm;
+import core.thread.fiber;
 
 /////////////////////////////////////////////////////////////
 // 3. スケルトン上の連続パスを DFS で抽出する（visited も NDslice で管理）
@@ -139,6 +140,7 @@ vec2u[] extractPath(T)(T skeleton, int width, int height)
                 if (result2[1].length > longestPathOverall.length)
                     longestPathOverall = result2[1];
             }
+            Fiber.yield();
         }
     }
     return longestPathOverall;

--- a/source/nijigenerate/core/math/skeletonize.d
+++ b/source/nijigenerate/core/math/skeletonize.d
@@ -5,7 +5,7 @@ import inmath;
 import std.algorithm;
 import std.array;
 import std.algorithm.iteration: uniq;
-
+import core.thread.fiber;
 
 
 /////////////////////////////////////////////////////////////
@@ -171,5 +171,6 @@ void skeletonizeImage(T)(T imbin) {
             if (candidates.length == 0)
                 break;
         }
+        Fiber.yield();
     }
 }

--- a/source/nijigenerate/viewport/vertex/package.d
+++ b/source/nijigenerate/viewport/vertex/package.d
@@ -217,7 +217,7 @@ public:
                                 e.setMesh(newMesh);
                             }
                             import core.memory: pageSize;
-                            auto fib = new Fiber(&worker, pageSize * 32);
+                            auto fib = new Fiber(&worker, pageSize * Fiber.defaultStackPages * 4);
                             while (fib.state != Fiber.State.TERM) {
                                 fib.call();
                             }

--- a/source/nijigenerate/windows/automeshbatch.d
+++ b/source/nijigenerate/windows/automeshbatch.d
@@ -171,7 +171,7 @@ protected:
         void work() {
             ngActiveAutoMeshProcessor.autoMesh(targets, meshList, false, 0, false, 0, &callback);
         }
-        auto fib = new Fiber(&work, core.memory.pageSize * 32);
+        auto fib = new Fiber(&work, core.memory.pageSize * Fiber.defaultStackPages * 4);
         while (fib.state != Fiber.State.TERM) {
             fib.call();
             bool result = false;

--- a/source/nijigenerate/windows/automeshbatch.d
+++ b/source/nijigenerate/windows/automeshbatch.d
@@ -157,7 +157,9 @@ protected:
         auto meshList = targets.map!(t=>meshes[t.uuid]).array;
         status.clear();
         foreach (t; targets) status[t.uuid] = Status.Waiting;
+        Drawable currentTarget = null;
         bool callback(Drawable drawable, IncMesh mesh) {
+            currentTarget = drawable;
             if (mesh is null) {
                 status[drawable.uuid] = Status.Running;
             } else {
@@ -177,6 +179,9 @@ protected:
             bool result = false;
             synchronized(gcMutex) { result = canceled; }
             if (result) {
+                if (currentTarget) {
+                    status[currentTarget.uuid] = Status.Failed;
+                }
                 break;
             }
         }


### PR DESCRIPTION
Time consuming task like automesh should be cancelled if user specify to cancel.
This patch introduces fiber for automesh and related time-consuming task, so if user specify to cancel, it discards the task, and returns. 