### PR TITLE
Commands: fixed bug in "mode setting" command and related UI to work correctly.

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -29,6 +29,7 @@ import nijigenerate.windows.flipconfig;
 import nijilive;
 import nijigenerate;
 import i18n;
+import bindbc.sdl : SDL_SetHint; // allow screensaver
 
 version(D_X32) {
     pragma(msg, "nijigenerate does not support compilation on 32 bit platforms");
@@ -72,6 +73,8 @@ int main(string[] args)
         // Initialize Window and nijilive
         incInitPanels();
         incActionInit();
+        // Do not disable the OS screensaver; allow it explicitly.
+        SDL_SetHint("SDL_VIDEO_ALLOW_SCREENSAVER", "1");
         incOpenWindow();
 
         // Initialize node overrides

--- a/source/nijigenerate/commands/puppet/tool.d
+++ b/source/nijigenerate/commands/puppet/tool.d
@@ -125,8 +125,9 @@ class ModelEditModeCommand : ExCommand!() {
     override
     void run(Context ctx) {
         bool alreadySelected = incEditMode == EditMode.ModelEdit;
-        if (!alreadySelected)
+        if (!alreadySelected) {
             incSetEditMode(EditMode.ModelEdit);
+        }
     }
 }
 
@@ -137,8 +138,9 @@ class AnimEditModeCommand : ExCommand!() {
     override
     void run(Context ctx) {
         bool alreadySelected = incEditMode == EditMode.AnimEdit;
-        if (!alreadySelected)
+        if (!alreadySelected) {
             incSetEditMode(EditMode.AnimEdit);
+        }
     }
 }
 

--- a/source/nijigenerate/core/window.d
+++ b/source/nijigenerate/core/window.d
@@ -186,6 +186,8 @@ void incOpenWindow() {
     }
 
     SDL_Init(SDL_INIT_EVERYTHING);
+    // Do not disable the OS screensaver; allow it explicitly.
+    SDL_EnableScreenSaver();
     
     version(Windows) {
         incSetWin32DPIAwareness();

--- a/source/nijigenerate/widgets/mainmenu.d
+++ b/source/nijigenerate/widgets/mainmenu.d
@@ -337,14 +337,35 @@ void incMainMenu() {
         igSetNextItemWidth (avail.x - tabBarWidth);
         igBeginTabBar("###ModeTab");
             if(incEditMode != EditMode.VertexEdit) {
-                if (igBeginTabItem("%s".format(_("Edit Puppet")).toStringz, null)) {
-                    cmd!(ToolCommand.ModelEditMode)(ctx);
+                auto mode = incEditMode; // snapshot for this frame
+
+                // Use a persistent tab selection to avoid per-frame toggling.
+                // Only request SetSelected when mode changed externally (e.g., shortcut).
+                static EditMode tabSelected = EditMode.ModelEdit;
+                ImGuiTabItemFlags modelFlags = ImGuiTabItemFlags.None;
+                ImGuiTabItemFlags animFlags  = ImGuiTabItemFlags.None;
+                if (tabSelected != mode) {
+                    if (mode == EditMode.ModelEdit) modelFlags = ImGuiTabItemFlags.SetSelected;
+                    else if (mode == EditMode.AnimEdit) animFlags = ImGuiTabItemFlags.SetSelected;
+                    tabSelected = mode;
+                }
+
+                // Render tabs
+                if (igBeginTabItem(("" ~ _("Edit Puppet")).toStringz, null, modelFlags)) {
+                    // If user clicked this tab this frame, switch mode once.
+                    if (mode != EditMode.ModelEdit) {
+                        incSetEditMode(EditMode.ModelEdit);
+                        tabSelected = EditMode.ModelEdit;
+                    }
                     igEndTabItem();
                 }
                 incTooltip(_("Edit Puppet"));
 
-                if (igBeginTabItem("%s".format(_("Edit Animation")).toStringz, null)) {
-                    cmd!(ToolCommand.AnimEditMode)(ctx);
+                if (igBeginTabItem(("" ~ _("Edit Animation")).toStringz, null, animFlags)) {
+                    if (mode != EditMode.AnimEdit) {
+                        incSetEditMode(EditMode.AnimEdit);
+                        tabSelected = EditMode.AnimEdit;
+                    }
                     igEndTabItem();
                 }
                 incTooltip(_("Edit Animation"));


### PR DESCRIPTION
EditMode cannot set correctly from command line, due to the delay of the change in active tab.
In original implementation, when user switches the edit mode by shortcut, edit mode was changed back to original mode, since tab status in main menu is not updated, and reset the mode to previous one.
This patch fixes that bug.

In addition to that, this patch tries to enable screensaver, which was disabled even in editor.