### PR TITLE
feature/command palette3

### DIFF
--- a/source/nijigenerate/commands/package.d
+++ b/source/nijigenerate/commands/package.d
@@ -12,6 +12,7 @@ public import nijigenerate.commands.puppet.edit;
 public import nijigenerate.commands.puppet.view;
 public import nijigenerate.commands.puppet.tool;
 public import nijigenerate.commands.viewport.control;
+public import nijigenerate.commands.viewport.palette;
 public import nijigenerate.commands.mesheditor.tool;
 public import nijigenerate.commands.view.panel;
 public import nijigenerate.commands.inspector.apply_node;
@@ -33,6 +34,7 @@ alias AllCommandMaps = AliasSeq!(
     nijigenerate.commands.puppet.view.commands,
     nijigenerate.commands.puppet.tool.commands,
     nijigenerate.commands.viewport.control.commands,
+    nijigenerate.commands.viewport.palette.commands,
     nijigenerate.commands.mesheditor.tool.selectToolModeCommands,
     nijigenerate.commands.view.panel.togglePanelCommands,
     nijigenerate.commands.node.dynamic.addNodeCommands,

--- a/source/nijigenerate/commands/viewport/palette.d
+++ b/source/nijigenerate/commands/viewport/palette.d
@@ -1,0 +1,197 @@
+module nijigenerate.commands.viewport.palette;
+
+import bindbc.imgui;
+import nijigenerate.commands.base;
+import nijigenerate.widgets.inputtext; // incInputText
+import nijigenerate.widgets.notification; // NotificationPopup
+import nijigenerate.commands; // AllCommandMaps
+import nijigenerate.widgets.dummy; // incAvailableSpace
+import i18n;
+import std.string : toStringz, toLower;
+import std.algorithm.searching : canFind, countUntil;
+import std.algorithm.comparison : min;
+
+// Command Palette for viewport: searchable list of commands
+
+enum PaletteCommand {
+    // Note: keeping the enum member name as requested
+    // This implies the command class will be ListCommandCommand.
+    ListCommand,
+}
+
+Command[PaletteCommand] commands;
+
+void ngInitCommands(T)() if (is(T == PaletteCommand))
+{
+    import std.traits : EnumMembers;
+    static foreach (name; EnumMembers!PaletteCommand) {
+        static if (__traits(compiles, { mixin(registerCommand!(name)); }))
+            mixin(registerCommand!(name));
+    }
+}
+
+// Internal state for the popup interaction
+private __gshared string gPaletteQuery;
+private __gshared size_t gPaletteSelectedIndex;
+private __gshared bool gPaletteActive;
+private __gshared bool gPaletteFocusPending;
+
+private void paletteOpen()
+{
+    gPaletteQuery = "";
+    gPaletteSelectedIndex = 0;
+    gPaletteActive = true;
+    gPaletteFocusPending = true;
+}
+
+private void paletteClose()
+{
+    gPaletteActive = false;
+    NotificationPopup.instance().close();
+}
+
+// Collect all registered commands across AllCommandMaps
+private Command[] collectAllCommands()
+{
+    Command[] arr;
+    static foreach (AA; AllCommandMaps) {
+        foreach (k, v; AA) {
+            if (v !is null) arr ~= v;
+        }
+    }
+    return arr;
+}
+
+/// Show a searchable list and execute on Enter.
+class ListCommandCommand : ExCommand!()
+{
+    this() { super(_("Show Command Palette.")); }
+
+    override void run(Context ctx)
+    {
+        auto self = this; // capture for exclusion
+        paletteOpen();
+
+        NotificationPopup.instance().popup((ImGuiIO* io) {
+            if (!gPaletteActive) return; // closed
+
+            // Input field
+            // Width: half of viewport area width
+            float halfW = io.DisplaySize.x * 0.5f;
+            igPushItemWidth(halfW);
+            if (gPaletteFocusPending) {
+                igSetKeyboardFocusHere(0);
+                gPaletteFocusPending = false;
+            }
+            bool submitted = incInputText("PALETTE_QUERY", gPaletteQuery, ImGuiInputTextFlags.EnterReturnsTrue);
+            igPopItemWidth();
+
+            // Gather and filter commands by label substring (case-insensitive)
+            string q = gPaletteQuery.toLower;
+            Command[] all = collectAllCommands();
+
+            Command[] filtered;
+            foreach (c; all) {
+                if (c is null) continue;
+                if (c is self) continue; // exclude self
+                auto lbl = c.label();
+                if (q.length == 0 || canFind(lbl.toLower, q)) {
+                    filtered ~= c;
+                }
+            }
+
+            // Adjust selection bounds
+            if (gPaletteSelectedIndex >= filtered.length) {
+                gPaletteSelectedIndex = filtered.length > 0 ? filtered.length - 1 : 0;
+            }
+
+            // Navigation keys
+            if (igIsKeyPressed(ImGuiKey.DownArrow, true)) {
+                if (filtered.length > 0 && gPaletteSelectedIndex + 1 < filtered.length)
+                    ++gPaletteSelectedIndex;
+            }
+            if (igIsKeyPressed(ImGuiKey.UpArrow, true)) {
+                if (filtered.length > 0 && gPaletteSelectedIndex > 0)
+                    --gPaletteSelectedIndex;
+            }
+            // Close on Escape
+            if (igIsKeyPressed(ImGuiKey.Escape)) {
+                paletteClose();
+                return;
+            }
+
+            // Results list with scrolling when exceeding viewport height
+            float lineH = igGetTextLineHeightWithSpacing();
+            float estimated = filtered.length * lineH;
+            float maxListH = io.DisplaySize.y * 0.8f;
+            float listH = estimated < maxListH ? estimated : maxListH;
+            if (listH < lineH * 3 && filtered.length > 0) listH = lineH * filtered.length; // minimal fit
+
+            if (igBeginChild("PALETTE_RESULTS", ImVec2(halfW, listH), true, ImGuiWindowFlags.AlwaysVerticalScrollbar)) {
+                import nijigenerate.core.shortcut : ngShortcutFor;
+                foreach (i, c; filtered) {
+                    auto lbl = c.label();
+                    bool selected = (i == gPaletteSelectedIndex);
+                    if (igSelectable(lbl.toStringz, selected)) {
+                        gPaletteSelectedIndex = i;
+                        // Execute on mouse selection
+                        executeCommand(c);
+                        igEndChild();
+                        return;
+                    }
+                    // Render shortcut at right end if assigned
+                    auto sc = ngShortcutFor(c);
+                    if (sc.length) {
+                        import std.string : toStringz;
+                        ImVec2 sz; igCalcTextSize(&sz, sc.toStringz);
+//                        ImVec2 rmin, rmax; igGetWindowContentRegionMin(&rmin); igGetWindowContentRegionMax(&rmax);
+                        ImVec2 rmax = incAvailableSpace();
+                        auto style = igGetStyle();
+                        // account for vertical scrollbar reservation and right padding
+                        float rightX = rmax.x - sz.x - style.ItemInnerSpacing.x - style.ScrollbarSize;
+                        float curX = igGetCursorPosX();
+                        float off = rightX - curX;
+                        if (off > 0) igSameLine(0, off);
+                        igText(sc.toStringz);
+                    }
+                }
+            }
+            igEndChild();
+
+            // Execute on Enter
+            if (submitted || igIsKeyPressed(ImGuiKey.Enter)) {
+                if (filtered.length > 0) {
+                    auto c = filtered[min(gPaletteSelectedIndex, filtered.length - 1)];
+                    executeCommand(c);
+                    return;
+                }
+            }
+
+            // Close on Escape or click outside the palette window
+            if (igIsKeyPressed(ImGuiKey.Escape)) {
+                paletteClose();
+                return;
+            }
+            // Close on outside click only if not interacting with any item in this frame
+            if (igIsMouseClicked(ImGuiMouseButton.Left) &&
+                !(igIsWindowHovered(ImGuiHoveredFlags.ChildWindows) || igIsAnyItemHovered())) {
+                paletteClose();
+                return;
+            }
+        }, -1); // infinite until closed
+    }
+
+private:
+    void executeCommand(Command c)
+    {
+        import nijigenerate.core.shortcut.base : ngBuildExecutionContext; // wrapper to build Context
+        auto ctx = ngBuildExecutionContext();
+        if (c !is null && c.runnable(ctx)) {
+            c.run(ctx);
+            paletteClose();
+        } else {
+            // Keep palette open if command cannot run in current context
+            // Optionally, we could show a status message here.
+        }
+    }
+}

--- a/source/nijigenerate/core/shortcut/defaults.d
+++ b/source/nijigenerate/core/shortcut/defaults.d
@@ -8,6 +8,7 @@ import nijigenerate.commands.puppet.file;
 import nijigenerate.commands.puppet.edit;
 import nijigenerate.commands.node.node;
 import nijigenerate.commands.viewport.control;
+import nijigenerate.commands.viewport.palette;
 import nijigenerate.core.input : _K;
 
 void ngRegisterDefaultShortcuts()
@@ -28,5 +29,7 @@ void ngRegisterDefaultShortcuts()
     ngRegisterShortcut(_K!"Ctrl-V", nijigenerate.commands.node.node.commands[NodeCommand.PasteNode], true);
 
     // Viewport control (add when appropriate)
-}
 
+    // Palette
+    ngRegisterShortcut(_K!"Ctrl-Shift-P", nijigenerate.commands.viewport.palette.commands[PaletteCommand.ListCommand]);
+}

--- a/source/nijigenerate/widgets/notification.d
+++ b/source/nijigenerate/widgets/notification.d
@@ -47,14 +47,17 @@ public:
 
             igSetNextWindowPos(ImVec2(viewportSize.x * 0.5f - 150, 0), ImGuiCond.Always, ImVec2(0.5f, 0.0f));
 
-            ImVec2 textSize;
-            igCalcTextSize(&textSize, messagez);
-
-            igSetNextWindowSize(ImVec2(textSize.x + 100, 50), ImGuiCond.Always);
-
             ImGuiWindowFlags flags = ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoResize |
                                     ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoSavedSettings |
                                     ImGuiWindowFlags.NoScrollbar;
+            // For callback-driven content, allow auto-resize to fit widgets (e.g., dropdowns)
+            if (callback) {
+                flags |= ImGuiWindowFlags.AlwaysAutoResize;
+            } else {
+                ImVec2 textSize;
+                igCalcTextSize(&textSize, messagez);
+                igSetNextWindowSize(ImVec2(textSize.x + 100, 50), ImGuiCond.Always);
+            }
 
             ImVec4 lightGreen = ImVec4(0.67f, 0.75f, 0.63f, 1.00f); // 画像の明るい緑色に基づく
             igPushStyleColor(ImGuiCol.WindowBg, lightGreen);
@@ -62,13 +65,15 @@ public:
             if (igBegin("##NotificationPopup", null, flags))
             {
                 if (callback) {
+                    // For callback-driven content (e.g., dropdown lists), rely on ESC/outside-click to close.
+                    // Avoid placing a close button on the same row to prevent layout issues.
                     callback(io);
                 } else if (messagez) {
                     igText(messagez);
-                }
-                igSameLine();
-                if (incButtonColored("\ue5cd", ImVec2(20, 20))){
-                    visible = false;
+                    igSameLine();
+                    if (incButtonColored("\ue5cd", ImVec2(20, 20))){
+                        visible = false;
+                    }
                 }
             }
 
@@ -80,5 +85,14 @@ public:
             }
         }
 
+    }
+
+    // Close and clear the popup immediately
+    void close() {
+        visible = false;
+        infinite = false;
+        statusTime = 0;
+        messagez = null;
+        callback = null;
     }
 }

--- a/source/nijigenerate/windows/settings.d
+++ b/source/nijigenerate/windows/settings.d
@@ -452,6 +452,7 @@ protected:
             renderCommandTable!(nijigenerate.commands.puppet.view.commands)(__("View"));
             renderCommandTable!(nijigenerate.commands.puppet.tool.commands)(__("Tools"));
             renderCommandTable!(nijigenerate.commands.viewport.control.commands)(__("Viewport"));
+            renderCommandTable!(nijigenerate.commands.viewport.palette.commands)(__("Palette"));
             renderCommandTable!(nijigenerate.commands.node.node.commands)(__("Node"));
             renderCommandTable!(nijigenerate.commands.inspector.apply_node.commands)(__("Inspector"));
             // Node add/insert (dynamic by node type)


### PR DESCRIPTION
- refactor: NotificationPopup support callback function to show arbitrary widgets.
- feat(viewport): add command palette with searchable dropdown and execution\n\n- Add nijigenerate.commands.viewport.palette (ListCommand)\n- Use NotificationPopup callback with auto-resize; focus input; half-viewport width\n- Scrollable result list with outside-click/ESC close; run on click/enter\n- Show right-aligned shortcuts per command; account for scrollbar/padding\n- Expose popup close API (NotificationPopup.close)\n- Integrate into settings Shortcuts (Palette section)\n- Register default shortcut Ctrl+Shift+P\n- Refactor shortcuts registry to Command-keyed AA for O(1) lookup
