### PR TITLE
feat(commands): hide non-runnable commands from shortcut editor

### DIFF
--- a/source/nijigenerate/commands/base.d
+++ b/source/nijigenerate/commands/base.d
@@ -128,6 +128,8 @@ interface Command {
     string description();  // longer human description
     /// Whether this command can run in the given context
     bool runnable(Context context);
+    /// Whether this command is eligible to be bound and edited as a shortcut
+    bool shortcutRunnable();
 }
 
 abstract class ExCommand(T...) : Command {
@@ -200,6 +202,7 @@ abstract class ExCommand(T...) : Command {
     override string label() { return _label.length ? _label : _desc; }
     override string description() { return _desc; }
     override bool runnable(Context context) { return true; }
+    override bool shortcutRunnable() { return true; }
     struct ArgMeta {
         string typeName;
         string fieldName;

--- a/source/nijigenerate/commands/inspector/apply_node.d
+++ b/source/nijigenerate/commands/inspector/apply_node.d
@@ -113,6 +113,9 @@ class ApplyInspectorPropCommand(I, string PropName) : ExCommand!(TW!(typeof(mixi
         if (ctx.hasNodes)
             ni.capture(cast(Node[])ctx.nodes);
     }
+
+    // Apply-style inspector commands require specifying values and are not suited for shortcuts
+    override bool shortcutRunnable() { return false; }
 }
 
 class ToggleInspectorPropCommand(I, string PropName) : ExCommand!() {

--- a/source/nijigenerate/commands/puppet/file.d
+++ b/source/nijigenerate/commands/puppet/file.d
@@ -36,6 +36,9 @@ class OpenFileCommand : ExCommand!(TW!(string, "file", "specifies file path.")) 
     void run(Context ctx) {
         if (file) incOpenProject(file);
     }
+
+    // Do not expose direct-execution variant to shortcut editor (use dialog command)
+    override bool shortcutRunnable() { return false; }
 }
 
 class ShowSaveFileDialogCommand : ExCommand!() {
@@ -54,6 +57,9 @@ class SaveFileCommand : ExCommand!(TW!(string, "file", "specifies file path.")) 
     void run(Context ctx) {
         if (file) incSaveProject(file);
     }
+
+    // Do not expose direct-execution variant to shortcut editor (use dialog command)
+    override bool shortcutRunnable() { return false; }
 }
 
 class ShowSaveFileAsDialogCommand : ExCommand!() {

--- a/source/nijigenerate/windows/settings.d
+++ b/source/nijigenerate/windows/settings.d
@@ -311,6 +311,9 @@ protected:
                 igTableHeadersRow();
 
                 foreach (k, cmd; CmdsAA) {
+                    // Hide commands that are not intended to be bound as shortcuts
+                    if (!cmd.shortcutRunnable())
+                        continue;
                     igTableNextRow(ImGuiTableRowFlags.None, 0.0);
                     igTableSetColumnIndex(0);
                     auto lbl = cmd.label();


### PR DESCRIPTION
This PR introduces a `shortcutRunnable()` flag to the Command API and wires the shortcut editor UI to hide commands that should not be directly invoked via shortcuts.

Changes:
- Add `Command.shortcutRunnable()` (default true via `ExCommand`).
- Mark direct file operations as not shortcut-bindable:
  - `OpenFileCommand`, `SaveFileCommand` return `false`.
- Filter the Settings → Shortcuts table to omit non-runnable commands.
- Mark Inspector Apply* commands as not shortcut-bindable (value-taking), while Toggle* remain allowed.

Rationale:
- Certain actions (e.g., Save/Load/Import/Merge direct execution, Inspector Apply with explicit values) should go through dialogs or context UI rather than be bound to raw shortcuts.

Build:
- Verified with `dub build -c linux-full`.

