### PR TITLE
Command Palette Enhancements

### DIFF
--- a/source/nijigenerate/commands/viewport/palette.d
+++ b/source/nijigenerate/commands/viewport/palette.d
@@ -200,7 +200,8 @@ class ListCommandCommand : ExCommand!()
 
             // Results list with scrolling when exceeding viewport height
             float lineH = igGetTextLineHeightWithSpacing();
-            float estimated = filtered.length * lineH;
+            import std.algorithm : max;
+            float estimated = max(filtered.length, 4) * lineH; // always more then 4 prevent 1 element underflow
             float maxListH = io.DisplaySize.y * 0.8f;
             float listH = estimated < maxListH ? estimated : maxListH;
             if (listH < lineH * 3 && filtered.length > 0) listH = lineH * filtered.length; // minimal fit


### PR DESCRIPTION
## Summary
This PR improves the **Command Palette** in the viewport by:
- Implementing `deriveEnglishToken` to make commands searchable via their type name (e.g. typing `open` finds `OpenFileCommand` → `[檔案] 開啟`).
  -  Using English input is reasonable because ImGui has limited support for CJK input.
- Adding group/category matching so commands can also be found by their parent group name (e.g. searching `檔案` or `File` lists all `nijigenerate.commands.puppet.file.commands`).
- Improving the list height calculation to prevent underflow by ensuring at least 4 elements are considered.

## Screenshots
1. Searching in English (`open`) successfully finds i18n-translated commands (UI shows: `[檔案] 開啟`).
<img width="329" height="98" alt="example_open_i18n" src="https://github.com/user-attachments/assets/fa285d1e-280c-452f-857c-38cbe61324bc" />

2. Searching by group name (`檔案` or `File`) returns all commands in the `File` group (`nijigenerate.commands.puppet.file.commands`).

<img width="363" height="202" alt="file_example" src="https://github.com/user-attachments/assets/53301ccf-17c6-4f46-9e8a-ee2df63e0210" />

<img width="379" height="137" alt="file_example_2" src="https://github.com/user-attachments/assets/d3c8470f-43e0-4857-874a-0cfff186cc4e" />


## Implementation Notes
- Introduced `getParentCategory` as a temporary solution for mapping commands to group names.
- **Why show the group?** Different groups may contain commands with identical or very similar labels. Displaying the group name alongside the command makes it much easier for users to recognize and select the correct one.
- This implementation is **hard-coded and has low cohesion**, making it harder to maintain.  
  A more sustainable approach could involve introducing a `CommandGroup` abstraction.  
  We tried modifying the code in that direction, but found it would affect **at least 17 files**, making the change too large in scope for this PR.
- **Note:** We derive the English token by reading from the `Object` type name instead of `label()`, because labels are already passed through i18n and no longer reflect the original command name.  
  Ideally, there should be a proper way to access both the i18n-translated label and the original English string. Currently, I am not sure if there exists a built-in method to retrieve the original text and its translation.

## Related Commits
- 80db1fe Implement `deriveEnglishToken` for enhanced search.
- bdf7141 Display parent group in search results and allow filtering by group.
- 6082c00 Fix list height underflow issue by enforcing a minimum element count.
