### PR TITLE
Shortcuts Pane Filter

### DIFF
--- a/source/nijigenerate/windows/settings.d
+++ b/source/nijigenerate/windows/settings.d
@@ -32,7 +32,7 @@ enum SettingsPane : string {
     Viewport = "Viewport",
     Accessibility = "Accessbility",
     FileHandling = "File Handling",
-    Shotcuts = "Shotcuts",
+    Shortcuts = "Shortcuts",
 }
 
 /**
@@ -113,8 +113,8 @@ protected:
                     settingsPane = SettingsPane.FileHandling;
                 }
 
-                if (igSelectable(__("Shotcuts"), settingsPane == SettingsPane.Shotcuts)) {
-                    settingsPane = SettingsPane.Shotcuts;
+                if (igSelectable(__("Shortcuts"), settingsPane == SettingsPane.Shortcuts)) {
+                    settingsPane = SettingsPane.Shortcuts;
                 }
             igPopTextWrapPos();
         }
@@ -184,8 +184,8 @@ protected:
                             endSection();
                         }
                         break;
-                    case SettingsPane.Shotcuts:
-                        drawShotcutsPane();
+                    case SettingsPane.Shortcuts:
+                        drawShortcutsPane();
                         break;
                     case SettingsPane.Accessibility:
                         beginSection(__("Accessibility"));
@@ -484,8 +484,8 @@ protected:
         igSeparator();
     }
 
-    void drawShotcutsPane() {
-        beginSection(__("Shotcuts"));
+    void drawShortcutsPane() {
+        beginSection(__("Shortcuts"));
             incText(_("Assign shortcuts to commands. Click Set and press keys. Use Clear to remove a binding."));
 
             // macOS-specific option: swap Command and Control in shortcuts

--- a/source/nijigenerate/windows/settings.d
+++ b/source/nijigenerate/windows/settings.d
@@ -322,6 +322,17 @@ public:
     }
 
 protected:
+    // Helper function to check if any commands in an AA match the current filter
+    bool hasMatchingCommands(alias CmdsAA)() {
+        foreach (k, cmd; CmdsAA) {
+            if (!cmd.shortcutRunnable()) continue;
+            if (shortcutFilter.length == 0) return true;
+            auto lbl = cmd.label();
+            if (to!string(lbl).toLower().indexOf(shortcutFilter.toLower()) != -1) return true;
+        }
+        return false;
+    }
+
     // Render a simple 2-column table for a commands AA (enum => Command)
     void renderCommandTable(alias CmdsAA)(const(char)* title)
     {
@@ -527,7 +538,12 @@ protected:
             renderCommandTable!(nijigenerate.commands.mesheditor.tool.selectToolModeCommands)(__("Mesh Editor Tools"));
 
             // ===== Node Popup =====
-            if (incBeginCategory(__("Nodes"))) {
+            bool hasNodeCommands = hasMatchingCommands!(nijigenerate.commands.node.node.commands)() ||
+                                   hasMatchingCommands!(nijigenerate.commands.node.dynamic.addNodeCommands)() ||
+                                   hasMatchingCommands!(nijigenerate.commands.node.dynamic.insertNodeCommands)() ||
+                                   hasMatchingCommands!(nijigenerate.commands.node.dynamic.convertNodeCommands)();
+            
+            if (hasNodeCommands && incBeginCategory(__("Nodes"))) {
                 renderCommandTable!(nijigenerate.commands.node.node.commands)(__("Nodes"));
                 // Add / Insert / Convert Nodes...
                 renderCommandTable!(nijigenerate.commands.node.dynamic.addNodeCommands)(__("Add Node"));


### PR DESCRIPTION
## Summary
This PR improves the **Shortcuts** pane in the settings window by:
- Correcting a typo in the pane name (`Shotcuts` → `Shortcuts`) across the enum, UI selection, and rendering function.
- Adding **filtering functionality** for commands with shortcuts, allowing users to search commands by name.
- Updating the command table to only render commands that match the filter, improving usability in large command sets.

## Screenshots
1. Shortcuts pane now displays correctly as `Shortcuts` instead of `Shotcuts`.
<img width="520" height="237" alt="typo" src="https://github.com/user-attachments/assets/760f0c7d-bdb7-4b8d-abfd-8a879eff85aa" />

2. Filtering example: typing a keyword in the filter input shows only matching commands, making it easier to find specific shortcuts.
<img width="417" height="277" alt="filter_example1" src="https://github.com/user-attachments/assets/6750dd7e-8334-4eb3-8539-aeceba711a1a" />
<img width="401" height="269" alt="filter_example2" src="https://github.com/user-attachments/assets/99d32281-d716-4d03-9388-2718b636e141" />


## Implementation Notes
- A new `shortcutFilterBuffer` is used to capture user input, and `shortcutFilter` stores the current filter string.
- In `renderCommandTable`, we first build a list of commands matching the filter (`filteredKeys`) and then render only those rows.
- Commands that are not `shortcutRunnable()` are automatically skipped.
- Enum-ordered iteration is preserved for enum-based command lists, while other AA types are rendered in key order.
- This design ensures that the table remains scrollable and headers stay visible while filtering.
- Minor cleanup: removed redundant helper code and import statements, consolidating rendering logic for clarity.
- Added `hasMatchingCommands` helper to check if a category has any commands matching the current filter.
  This prevents rendering empty TreeNodes and avoids the ImGui assertion crash:
  `Assertion failed: (SizeOfIDStack == window->IDStack.Size && "PushID/PopID or TreeNode/TreePop Mismatch!")`.
  It is used before calling `incBeginCategory` to skip empty categories.

## Related Commits
- 1ddfa32 Add filtering functionality for shortcut commands in settings.
- 3a147c3 Correct spelling of "Shortcuts" in settings pane.
- 05eef15 fixed empty treenode crash