### PR TITLE
feat(commands,parameditor): add parameter property commands and preserve bindings across axis edits

### DIFF
--- a/source/nijigenerate/commands/package.d
+++ b/source/nijigenerate/commands/package.d
@@ -7,6 +7,7 @@ public import nijigenerate.commands.parameter.animedit;
 public import nijigenerate.commands.parameter.group;
 public import nijigenerate.commands.parameter.param;
 public import nijigenerate.commands.parameter.paramedit;
+public import nijigenerate.commands.parameter.prop;
 public import nijigenerate.commands.puppet.file;
 public import nijigenerate.commands.puppet.edit;
 public import nijigenerate.commands.puppet.view;
@@ -29,6 +30,7 @@ alias AllCommandMaps = AliasSeq!(
     nijigenerate.commands.parameter.group.commands,
     nijigenerate.commands.parameter.param.commands,
     nijigenerate.commands.parameter.paramedit.commands,
+    nijigenerate.commands.parameter.prop.commands,
     nijigenerate.commands.puppet.file.commands,
     nijigenerate.commands.puppet.edit.commands,
     nijigenerate.commands.puppet.view.commands,

--- a/source/nijigenerate/commands/package.d
+++ b/source/nijigenerate/commands/package.d
@@ -49,9 +49,12 @@ alias AllCommandMaps = AliasSeq!(
 // Discover and initialize commands for each enum key present in AllCommandMaps.
 void ngInitAllCommands() {
     static foreach (AA; AllCommandMaps) {
+        import std.stdio;
+        writef("niInitCoomands: %s", KeyTypeOfAA!(AA).stringof);
         static if (__traits(compiles, { ngInitCommands!(KeyTypeOfAA!(AA))(); })) {
+            writefln("Calls");
             ngInitCommands!(KeyTypeOfAA!(AA))();
-        }
+        } else writefln("NOt called");
     }
     /*
     import std.stdio;

--- a/source/nijigenerate/commands/parameter/group.d
+++ b/source/nijigenerate/commands/parameter/group.d
@@ -44,14 +44,14 @@ class CreateParamGroupCommand : ExCommand!(TW!(int, "index", "")) {
     }
 }
 
-class ChangeGroupColorCommand : ExCommand!(TW!(vec3, "color", "color value for target Parameter Group.")) {
-    this(vec3 color = vec3(0,0,0)) { super("Change Parameter Group Color", color); }
+class ChangeGroupColorCommand : ExCommand!(TW!(float[3], "color", "color value for target Parameter Group.")) {
+    this(float[3] color = [0f, 0f, 0f]) { super("Change Parameter Group Color", color); }
     override
     void run(Context ctx) {
         if (!ctx.hasParameters || ctx.parameters.length < 1 || (cast(ExParameterGroup)ctx.parameters[0]) is null)
             return;
         auto group = cast(ExParameterGroup)ctx.parameters[0];
-        group.color = color;
+        group.color = vec3(color[0], color[1], color[2]);
     }
 }
 
@@ -89,4 +89,5 @@ void ngInitCommands(T)() if (is(T == GroupCommand))
     }
     mixin(registerCommand!(GroupCommand.MoveParameter, null, 0));
     mixin(registerCommand!(GroupCommand.CreateParamGroup, 0));
+    mixin(registerCommand!(GroupCommand.ChangeGroupColor, [0f, 0f, 0f]));
 }

--- a/source/nijigenerate/commands/parameter/prop.d
+++ b/source/nijigenerate/commands/parameter/prop.d
@@ -7,10 +7,12 @@ import nijigenerate.core;
 import nijigenerate.viewport.model.deform : incViewportNodeDeformNotifyParamValueChanged;
 import i18n;
 import nijilive; // vec2, Parameter
+import nijilive.core.param.binding : ValueParameterBinding, ParameterParameterBinding, DeformationParameterBinding;
 
 // Name only
 class SetParameterNameCommand : ExCommand!(TW!(string, "newName", "New parameter name")) {
     this(string newName) { super(_("Set Parameter Name"), newName); }
+    override bool shortcutRunnable() { return false; }
     override
     void run(Context ctx) {
         if (!ctx.hasParameters) return;
@@ -35,22 +37,50 @@ class SetParameterNameCommand : ExCommand!(TW!(string, "newName", "New parameter
 
 // Apply min/max and axis breakpoints (normalized values) together
 class ApplyParameterPropsAxesCommand : ExCommand!(
-    TW!(vec2,    "min",   "New min (x,y)"),
-    TW!(vec2,    "max",   "New max (x,y)"),
-    TW!(float[], "axisX", "Normalized X breakpoints (including endpoints)"),
-    TW!(float[], "axisY", "Normalized Y breakpoints (including endpoints; empty for 1D)")
+    TW!(float[2], "min",   "New min (x,y) as [2]"),
+    TW!(float[2], "max",   "New max (x,y) as [2]"),
+    TW!(float[],  "axisX", "Normalized X breakpoints (including endpoints)"),
+    TW!(float[],  "axisY", "Normalized Y breakpoints (including endpoints; empty for 1D)")
 ) {
-    this(vec2 min, vec2 max, float[] axisX, float[] axisY) {
+    this(float[2] min, float[2] max, float[] axisX, float[] axisY) {
         super(_("Apply Parameter Axes + Props"), min, max, axisX, axisY);
     }
+    override bool shortcutRunnable() { return false; }
     override
     void run(Context ctx) {
         if (!ctx.hasParameters) return;
         auto param = ctx.parameters[0];
 
+        // Convert to vec2 for internal use
+        vec2 vmin = vec2(min[0], min[1]);
+        vec2 vmax = vec2(max[0], max[1]);
+
+        // Snapshot old axis points and binding data before structural changes
+        float[] oldXs = param.axisPoints[0].dup;
+        float[] oldYs = param.axisPoints[1].dup;
+        struct SnapF { ValueParameterBinding b; float[][] vals; bool[][] set; }
+        struct SnapP { ParameterParameterBinding b; float[][] vals; bool[][] set; }
+        struct SnapD { DeformationParameterBinding b; Deformation[][] vals; bool[][] set; }
+        SnapF[] snapsF; SnapP[] snapsP; SnapD[] snapsD;
+        foreach (binding; param.bindings) {
+            if (auto vb = cast(ValueParameterBinding)binding) {
+                float[][] vals; vals.length = oldXs.length; foreach (x; 0..oldXs.length) { vals[x].length = oldYs.length; foreach (y; 0..oldYs.length) vals[x][y] = vb.getValue(vec2u(cast(uint)x, cast(uint)y)); }
+                bool[][] set; set.length = oldXs.length; foreach (x; 0..oldXs.length) set[x] = vb.getIsSet()[x].dup;
+                snapsF ~= SnapF(vb, vals, set);
+            } else if (auto pb = cast(ParameterParameterBinding)binding) {
+                float[][] vals; vals.length = oldXs.length; foreach (x; 0..oldXs.length) { vals[x].length = oldYs.length; foreach (y; 0..oldYs.length) vals[x][y] = pb.getValue(vec2u(cast(uint)x, cast(uint)y)); }
+                bool[][] set; set.length = oldXs.length; foreach (x; 0..oldXs.length) set[x] = pb.getIsSet()[x].dup;
+                snapsP ~= SnapP(pb, vals, set);
+            } else if (auto db = cast(DeformationParameterBinding)binding) {
+                Deformation[][] vals; vals.length = oldXs.length; foreach (x; 0..oldXs.length) { vals[x].length = oldYs.length; foreach (y; 0..oldYs.length) vals[x][y] = db.getValue(vec2u(cast(uint)x, cast(uint)y)); }
+                bool[][] set; set.length = oldXs.length; foreach (x; 0..oldXs.length) set[x] = db.getIsSet()[x].dup;
+                snapsD ~= SnapD(db, vals, set);
+            }
+        }
+
         // Apply min/max via actions per component for proper undo/redo
         auto prevMin = param.min; auto prevMax = param.max;
-        param.min = min; param.max = max;
+        param.min = vmin; param.max = vmax;
         if (prevMin.x != param.min.x)
             incActionPush(new ParameterValueChangeAction!float("min X", param, prevMin.x, param.min.x, &param.min.vector[0]));
         if (param.isVec2 && prevMin.y != param.min.y)
@@ -61,18 +91,72 @@ class ApplyParameterPropsAxesCommand : ExCommand!(
             incActionPush(new ParameterValueChangeAction!float("max Y", param, prevMax.y, param.max.y, &param.max.vector[1]));
 
         // Helper to rewrite axis points to provided normalized list
-        void applyAxis(uint axis, float[] vals) {
-            // Guard: endpoints should exist; ensure strictly increasing order
+        void applyAxis(uint axis, float[] targetVals) {
             import std.algorithm : sort;
-            sort(vals);
-            // Remove all mid points keeping endpoints
-            while (param.axisPoints[axis].length > 2) {
-                param.deleteAxisPoint(axis, 1);
+            import std.math : abs;
+            // Ensure ascending and presence of endpoints
+            targetVals.sort();
+            if (targetVals.length < 2) return;
+
+            // Current points
+            float[] curVals;
+            foreach (v; param.axisPoints[axis]) curVals ~= v;
+            size_t curN = curVals.length;
+            size_t tarN = targetVals.length;
+
+            // Match endpoints implicitly
+            // Build matching between mid points by nearest neighbor
+            bool[] curMatched; curMatched.length = curN;
+            bool[] tarMatched; tarMatched.length = tarN;
+            if (curN >= 1 && tarN >= 1) { curMatched[0] = true; tarMatched[0] = true; }
+            if (curN >= 2 && tarN >= 2) { curMatched[curN-1] = true; tarMatched[tarN-1] = true; }
+
+            // For each target mid-point, pick nearest unmatched current mid-point
+            for (size_t tj = 1; tj + 1 < tarN; ++tj) {
+                float t = targetVals[tj];
+                float bestDist = float.infinity;
+                size_t bestIdx = size_t.max;
+                for (size_t ci = 1; ci + 1 < curN; ++ci) {
+                    if (curMatched[ci]) continue;
+                    float d = abs(curVals[ci] - t);
+                    if (d < bestDist) { bestDist = d; bestIdx = ci; }
+                }
+                if (bestIdx != size_t.max) {
+                    curMatched[bestIdx] = true;
+                    tarMatched[tj] = true;
+                }
             }
-            // Insert all mid-points (skip endpoints at index 0 and last)
-            foreach (i, v; vals) {
-                if (i == 0 || i == vals.length - 1) continue;
-                param.insertAxisPoint(axis, v);
+
+            // Delete unmatched current mid-points (ascending index)
+            if (curN > 2) {
+                size_t i = 1;
+                while (i + 1 < curN) {
+                    if (!curMatched[i]) {
+                        param.deleteAxisPoint(axis, cast(uint)i);
+                        // Update arrays after deletion
+                        curVals = curVals[0 .. i] ~ curVals[i+1 .. $];
+                        curMatched = curMatched[0 .. i] ~ curMatched[i+1 .. $];
+                        curN--;
+                        // Do not increment i, since next element shifted into i
+                        continue;
+                    }
+                    i++;
+                }
+            }
+
+            // Insert unmatched target mid-points
+            for (size_t tj = 1; tj + 1 < tarN; ++tj) {
+                if (!tarMatched[tj]) {
+                    param.insertAxisPoint(axis, targetVals[tj]);
+                }
+            }
+
+            // Now lengths should match; set positions to exact target values in order
+            // Refresh current length
+            curN = param.axisPoints[axis].length;
+            // Sanity: rely on engine keeping axisPoints sorted; assign by index
+            for (size_t i = 1; i + 1 < curN && i + 1 < tarN; ++i) {
+                param.axisPoints[axis][i] = targetVals[i];
             }
         }
 
@@ -80,7 +164,105 @@ class ApplyParameterPropsAxesCommand : ExCommand!(
         if (axisX.length >= 2) applyAxis(0, axisX);
         if (param.isVec2 && axisY.length >= 2) applyAxis(1, axisY);
 
-        // Notify deformers
+        // Remap all binding values by nearest neighbor in normalized space
+        // Use tolerance based on half of old cell size so that far points become unset
+        float[] newXs = param.axisPoints[0];
+        float[] newYs = param.axisPoints[1];
+        auto nearestIndex = (const float[] arr, float v) {
+            size_t best = 0; float bestd = float.infinity;
+            foreach (i, a; arr) { float d = a - v; if (d < 0) d = -d; if (d < bestd) { bestd = d; best = i; } }
+            return best;
+        };
+        auto halfCell = (const float[] arr) {
+            float[] hw; hw.length = arr.length;
+            if (arr.length == 0) return hw;
+            foreach (i, a; arr) {
+                float leftGap = i > 0 ? a - arr[i-1] : (arr.length > 1 ? arr[1] - a : 1.0f);
+                float rightGap = i+1 < arr.length ? arr[i+1] - a : (arr.length > 1 ? a - arr[i-1] : 1.0f);
+                float gap = leftGap < rightGap ? leftGap : rightGap;
+                hw[i] = gap * 0.5f;
+            }
+            return hw;
+        };
+        float[] halfX = halfCell(oldXs);
+        float[] halfY = halfCell(oldYs);
+        // Helper for one-to-one nearest matching between old and new grid points
+        struct Pair { size_t xi, yi, ox, oy; float d; }
+        auto buildPairs = (const float[] xsN, const float[] ysN, const float[] xsO, const float[] ysO) {
+            Pair[] pairs;
+            foreach (xi; 0..xsN.length) foreach (yi; 0..ysN.length) {
+                foreach (ox; 0..xsO.length) foreach (oy; 0..ysO.length) {
+                    float dx = xsN[xi] - xsO[ox]; if (dx < 0) dx = -dx;
+                    float dy = ysN[yi] - ysO[oy]; if (dy < 0) dy = -dy;
+                    pairs ~= Pair(xi, yi, ox, oy, dx+dy);
+                }
+            }
+            import std.algorithm : sort;
+            sort!((a,b)=>a.d<b.d)(pairs);
+            return pairs;
+        };
+        auto assignMatchesF = (ref SnapF s) {
+            s.b.clear();
+            size_t NX = newXs.length, NY = newYs.length, OX = oldXs.length, OY = oldYs.length;
+            bool[] matchedNew; matchedNew.length = NX*NY;
+            bool[] matchedOld; matchedOld.length = OX*OY;
+            auto LNi = (size_t x, size_t y){ return x*NY + y; };
+            auto LOi = (size_t x, size_t y){ return x*OY + y; };
+            auto pairs = buildPairs(newXs, newYs, oldXs, oldYs);
+            foreach (p; pairs) {
+                size_t iN = LNi(p.xi, p.yi);
+                size_t iO = LOi(p.ox, p.oy);
+                if (!matchedNew[iN] && !matchedOld[iO]) {
+                    matchedNew[iN] = true; matchedOld[iO] = true;
+                    if (s.set[p.ox][p.oy]) s.b.setValue(vec2u(cast(uint)p.xi, cast(uint)p.yi), s.vals[p.ox][p.oy]);
+                    else s.b.unset(vec2u(cast(uint)p.xi, cast(uint)p.yi));
+                }
+            }
+            s.b.reInterpolate();
+        };
+        auto assignMatchesP = (ref SnapP s) {
+            s.b.clear();
+            size_t NX = newXs.length, NY = newYs.length, OX = oldXs.length, OY = oldYs.length;
+            bool[] matchedNew; matchedNew.length = NX*NY;
+            bool[] matchedOld; matchedOld.length = OX*OY;
+            auto LNi = (size_t x, size_t y){ return x*NY + y; };
+            auto LOi = (size_t x, size_t y){ return x*OY + y; };
+            auto pairs = buildPairs(newXs, newYs, oldXs, oldYs);
+            foreach (p; pairs) {
+                size_t iN = LNi(p.xi, p.yi);
+                size_t iO = LOi(p.ox, p.oy);
+                if (!matchedNew[iN] && !matchedOld[iO]) {
+                    matchedNew[iN] = true; matchedOld[iO] = true;
+                    if (s.set[p.ox][p.oy]) s.b.setValue(vec2u(cast(uint)p.xi, cast(uint)p.yi), s.vals[p.ox][p.oy]);
+                    else s.b.unset(vec2u(cast(uint)p.xi, cast(uint)p.yi));
+                }
+            }
+            s.b.reInterpolate();
+        };
+        auto assignMatchesD = (ref SnapD s) {
+            s.b.clear();
+            size_t NX = newXs.length, NY = newYs.length, OX = oldXs.length, OY = oldYs.length;
+            bool[] matchedNew; matchedNew.length = NX*NY;
+            bool[] matchedOld; matchedOld.length = OX*OY;
+            auto LNi = (size_t x, size_t y){ return x*NY + y; };
+            auto LOi = (size_t x, size_t y){ return x*OY + y; };
+            auto pairs = buildPairs(newXs, newYs, oldXs, oldYs);
+            foreach (p; pairs) {
+                size_t iN = LNi(p.xi, p.yi);
+                size_t iO = LOi(p.ox, p.oy);
+                if (!matchedNew[iN] && !matchedOld[iO]) {
+                    matchedNew[iN] = true; matchedOld[iO] = true;
+                    if (s.set[p.ox][p.oy]) s.b.setValue(vec2u(cast(uint)p.xi, cast(uint)p.yi), s.vals[p.ox][p.oy]);
+                    else s.b.unset(vec2u(cast(uint)p.xi, cast(uint)p.yi));
+                }
+            }
+            s.b.reInterpolate();
+        };
+        foreach (i, ref s; snapsF) assignMatchesF(s);
+        foreach (i, ref s; snapsP) assignMatchesP(s);
+        foreach (i, ref s; snapsD) assignMatchesD(s);
+
+        // Notify after remap
         incViewportNodeDeformNotifyParamValueChanged();
     }
 }
@@ -94,9 +276,7 @@ Command[ParamPropCommand] commands;
 
 void ngInitCommands(T)() if (is(T == ParamPropCommand))
 {
-    import std.traits : EnumMembers;
-    static foreach (name; EnumMembers!ParamPropCommand) {
-        static if (__traits(compiles, { mixin(registerCommand!(name)); }))
-            mixin(registerCommand!(name));
-    }
+    // NOTE: Commands with ExCommand template args require explicit default args for registration
+    mixin(registerCommand!(ParamPropCommand.SetParameterName, ""));
+    mixin(registerCommand!(ParamPropCommand.ApplyParameterPropsAxes, [0f, 0f], [1f, 1f], new float[](0), new float[](0)));
 }

--- a/source/nijigenerate/commands/parameter/prop.d
+++ b/source/nijigenerate/commands/parameter/prop.d
@@ -1,0 +1,102 @@
+module nijigenerate.commands.parameter.prop;
+
+import nijigenerate.commands.base;
+import nijigenerate.ext;
+import nijigenerate.actions;
+import nijigenerate.core;
+import nijigenerate.viewport.model.deform : incViewportNodeDeformNotifyParamValueChanged;
+import i18n;
+import nijilive; // vec2, Parameter
+
+// Name only
+class SetParameterNameCommand : ExCommand!(TW!(string, "newName", "New parameter name")) {
+    this(string newName) { super(_("Set Parameter Name"), newName); }
+    override
+    void run(Context ctx) {
+        if (!ctx.hasParameters) return;
+        auto param = ctx.parameters[0];
+
+        // Validate name uniqueness within active puppet
+        auto ex = cast(ExPuppet) (ctx.hasPuppet ? ctx.puppet : null);
+        if (ex !is null) {
+            auto fparam = ex.findParameter(newName);
+            if (fparam !is null && fparam.uuid != param.uuid) {
+                // Name already taken; do nothing
+                return;
+            }
+        }
+
+        // Push name change as action
+        // No action push for name (pointer to property not supported); follow existing behavior
+        param.name = newName;
+        param.makeIndexable();
+    }
+}
+
+// Apply min/max and axis breakpoints (normalized values) together
+class ApplyParameterPropsAxesCommand : ExCommand!(
+    TW!(vec2,    "min",   "New min (x,y)"),
+    TW!(vec2,    "max",   "New max (x,y)"),
+    TW!(float[], "axisX", "Normalized X breakpoints (including endpoints)"),
+    TW!(float[], "axisY", "Normalized Y breakpoints (including endpoints; empty for 1D)")
+) {
+    this(vec2 min, vec2 max, float[] axisX, float[] axisY) {
+        super(_("Apply Parameter Axes + Props"), min, max, axisX, axisY);
+    }
+    override
+    void run(Context ctx) {
+        if (!ctx.hasParameters) return;
+        auto param = ctx.parameters[0];
+
+        // Apply min/max via actions per component for proper undo/redo
+        auto prevMin = param.min; auto prevMax = param.max;
+        param.min = min; param.max = max;
+        if (prevMin.x != param.min.x)
+            incActionPush(new ParameterValueChangeAction!float("min X", param, prevMin.x, param.min.x, &param.min.vector[0]));
+        if (param.isVec2 && prevMin.y != param.min.y)
+            incActionPush(new ParameterValueChangeAction!float("min Y", param, prevMin.y, param.min.y, &param.min.vector[1]));
+        if (prevMax.x != param.max.x)
+            incActionPush(new ParameterValueChangeAction!float("max X", param, prevMax.x, param.max.x, &param.max.vector[0]));
+        if (param.isVec2 && prevMax.y != param.max.y)
+            incActionPush(new ParameterValueChangeAction!float("max Y", param, prevMax.y, param.max.y, &param.max.vector[1]));
+
+        // Helper to rewrite axis points to provided normalized list
+        void applyAxis(uint axis, float[] vals) {
+            // Guard: endpoints should exist; ensure strictly increasing order
+            import std.algorithm : sort;
+            sort(vals);
+            // Remove all mid points keeping endpoints
+            while (param.axisPoints[axis].length > 2) {
+                param.deleteAxisPoint(axis, 1);
+            }
+            // Insert all mid-points (skip endpoints at index 0 and last)
+            foreach (i, v; vals) {
+                if (i == 0 || i == vals.length - 1) continue;
+                param.insertAxisPoint(axis, v);
+            }
+        }
+
+        // Apply breakpoints
+        if (axisX.length >= 2) applyAxis(0, axisX);
+        if (param.isVec2 && axisY.length >= 2) applyAxis(1, axisY);
+
+        // Notify deformers
+        incViewportNodeDeformNotifyParamValueChanged();
+    }
+}
+
+enum ParamPropCommand {
+    SetParameterName,
+    ApplyParameterPropsAxes,
+}
+
+Command[ParamPropCommand] commands;
+
+void ngInitCommands(T)() if (is(T == ParamPropCommand))
+{
+    import std.traits : EnumMembers;
+    static foreach (name; EnumMembers!ParamPropCommand) {
+        static if (__traits(compiles, { mixin(registerCommand!(name)); }))
+            mixin(registerCommand!(name));
+    }
+}

--- a/source/nijigenerate/commands/puppet/file.d
+++ b/source/nijigenerate/commands/puppet/file.d
@@ -313,4 +313,8 @@ void ngInitCommands(T)() if (is(T == FileCommand))
         static if (__traits(compiles, { mixin(registerCommand!(name)); }))
             mixin(registerCommand!(name));
     }
+    // Explicitly register ExCommand variants that require constructor args
+    // Provide benign defaults; actual values are supplied at call-time (e.g., MCP, dialogs)
+    mixin(registerCommand!(FileCommand.OpenFile, ""));
+    mixin(registerCommand!(FileCommand.SaveFile, ""));
 }


### PR DESCRIPTION
Summary:
- Add ParamProp commands and wire into AllCommandMaps.
- Register defaults for FileCommand Open/Save; align group color schema to float[3].
- ParamEditorWindow: save via commands; axis edit uses display order and keeps binding values by nearest remap.

Commits included:
- 88ccc12 feat(commands): add parameter property commands
- 53023ae fix(commands): register defaults for ExCommand with params and align group color schema
- 0b03357 parameditor/commands: preserve binding data across axis edits