### PR TITLE
Fix/command palette

### DIFF
--- a/source/nijigenerate/commands/node/node.d
+++ b/source/nijigenerate/commands/node/node.d
@@ -11,6 +11,7 @@ import nijigenerate.viewport.vertex;
 import nijilive;
 import nijigenerate.widgets;
 import i18n;
+import core.exception;
 
 
 //==================================================================================
@@ -33,7 +34,7 @@ class AddNodeCommand : ExCommand!(
             } else if (ctx.hasPuppet && ctx.puppet !is null) {
                 ngAddNodes([ctx.puppet.root], className, _suffix);
             }
-        } catch (Exception e) {
+        } catch (RangeError e) {
             // should return failure.
         }
     }
@@ -54,7 +55,7 @@ class InsertNodeCommand : ExCommand!(
             } else if (ctx.hasPuppet && ctx.puppet !is null) {
                 ngInsertNodes([ctx.puppet.root], className, _suffix);
             }
-        } catch (Exception e) {
+        } catch (RangeError e) {
             // should return failure.
         }
     }

--- a/source/nijigenerate/commands/node/node.d
+++ b/source/nijigenerate/commands/node/node.d
@@ -27,8 +27,15 @@ class AddNodeCommand : ExCommand!(
 
     override
     void run(Context ctx) {
-        if (ctx.hasNodes)
-            ngAddNodes(ctx.nodes, className, _suffix);
+        try {
+            if (ctx.hasNodes) {
+                ngAddNodes(ctx.nodes, className, _suffix);
+            } else if (ctx.hasPuppet && ctx.puppet !is null) {
+                ngAddNodes([ctx.puppet.root], className, _suffix);
+            }
+        } catch (Exception e) {
+            // should return failure.
+        }
     }
 }
 
@@ -41,8 +48,15 @@ class InsertNodeCommand : ExCommand!(
 
     override
     void run(Context ctx) {
-        if (ctx.hasNodes)
-            ngInsertNodes(ctx.nodes, className, _suffix);
+        try {
+            if (ctx.hasNodes) {
+                ngInsertNodes(ctx.nodes, className, _suffix);
+            } else if (ctx.hasPuppet && ctx.puppet !is null) {
+                ngInsertNodes([ctx.puppet.root], className, _suffix);
+            }
+        } catch (Exception e) {
+            // should return failure.
+        }
     }
 }
 


### PR DESCRIPTION
Two fixes for AddNodeCommand / InsertNodeCommand.

- Avoid crash when AddNodeCommand / InsertNodeCommand is executed with wrong Node class name.
- Use puppet.root if no parent node is specified. (this happens when no Node objects is selected.)