### PR TITLE
Add validation for camera size to prevent crashes and close pipe for Video Export 

### DIFF
--- a/source/nijigenerate/ext/nodes/excamera.d
+++ b/source/nijigenerate/ext/nodes/excamera.d
@@ -124,3 +124,13 @@ public:
 void incRegisterExCamera() {
     inRegisterNodeType!ExCamera();
 }
+
+bool incVerifyCameraSizeShowWarning(ref ExCamera selectedCamera) {
+    import nijigenerate.widgets;
+    import i18n;
+    if (selectedCamera.getViewport().x % 2 != 0 || selectedCamera.getViewport().y % 2 != 0) {
+        incTextColored(ImVec4(1, 0, 0, 1), _("Warning: Camera size must be divisible by 2"));
+        return true;
+    }
+    return false;
+}

--- a/source/nijigenerate/panels/inspector/camera.d
+++ b/source/nijigenerate/panels/inspector/camera.d
@@ -26,10 +26,11 @@ class NodeInspector(ModelEditSubMode mode: ModelEditSubMode.Layout, T: ExCamera)
             incText(_("Viewport"));
             igIndent();
                 igSetNextItemWidth(incAvailableSpace().x);
-                if (_shared!viewportOrigin(()=>igDragFloat2("###VIEWPORT", cast(float[2]*)(viewportOrigin.value.ptr)))) {
+                if (_shared!viewportOrigin(()=>igDragFloat2("###VIEWPORT", cast(float[2]*)(viewportOrigin.value.ptr), 2))) {
                     auto ctx = new Context(); ctx.inspectors = [this]; ctx.nodes(cast(Node[])targets);
                     cmd!(InspectorNodeApplyCommand.ViewportOrigin)(ctx, viewportOrigin.value);
                 }
+                incVerifyCameraSizeShowWarning(node);
             igUnindent();
 
             // Padding

--- a/source/nijigenerate/windows/videoexport.d
+++ b/source/nijigenerate/windows/videoexport.d
@@ -218,6 +218,10 @@ protected:
                     incEndCategory();
                 }
             }
+
+            // assert user camera size is not odd, it will cause ffmpeg to fail and crash
+            bool userAssertOdd = incVerifyCameraSizeShowWarning(selectedCamera);
+
             igEndChild();
         igEndDisabled();
 
@@ -227,7 +231,11 @@ protected:
             igSameLine(0, 4);
 
             if (!vctx) {
-                if (incButtonColored(__("Export"), ImVec2(64, 24))) {
+                igBeginDisabled(userAssertOdd);
+                    bool clicked = incButtonColored(__("Export"), ImVec2(64, 24));
+                igEndDisabled();
+
+                if (clicked) {
                     playback = player.createOrGet(animToExport);
 
                     loops = clamp(loops, 1, int.max);
@@ -269,6 +277,7 @@ protected:
                     }
                 } else {
                     if (incButtonColored(__("Close"), ImVec2(64, 24))) {
+                        vctx.end();
                         this.close();
                     }
                 }


### PR DESCRIPTION
upstream fix
- https://github.com/Inochi2D/inochi-creator/pull/411

commits
* Add validation for camera size to prevent ffmpeg crashes
* Close ffmpeg pipe on click close button
* Refactoring and setting steps

Note: This PR is intended only for tracking upstream PR
Actual functional fixes and video export improvements are implemented in a separate PR (https://github.com/nijigenerate/nijigenerate/pull/109). 
We separate them to keep the upstream tracking independent from feature or bug fixes.
