### PR TITLE
Add "Parameter Usage" menu to Node Actions Popup

### DIFF
--- a/source/nijigenerate/panels/nodes.d
+++ b/source/nijigenerate/panels/nodes.d
@@ -47,6 +47,7 @@ private {
             "Paste": "\ue14f",
             "Reload": "\ue5d5",
             "More Info": "\ue88e",
+            "Parameter Usage": "\ue429",
             "Recalculate origin": "\ue57b",
             "Convert To...": "\ue043",
         ];


### PR DESCRIPTION

## Description
This PR adds a new menu item to the Node Actions popup that shows which parameters reference the selected node.

## Changes
- Introduced a `Parameter Usage` menu in `incNodeActionsPopup`.
- Clicking a parameter in the menu toggles its arm state via `ParameditCommand.ToggleParameterArm`.
- Once clicked, the corresponding parameter becomes visible in the Parameters panel, eliminating the need to manually search for it.
- Displays a message when no parameters reference the node.

## Benefits
- Quickly see dependencies of a node from the right-click menu.
- Directly access and highlight parameters without navigating or searching manually.

## Screenshots
<img width="464" height="285" alt="find_and_arm_parameter_in_nodes" src="https://github.com/user-attachments/assets/eb123304-1c57-48d1-90ad-8dda6fc687d3" />

