### PR TITLE
fix(mesh-editor): type-safe prevent BezierDeform segfault

### DIFF
--- a/source/nijigenerate/viewport/common/mesheditor/tools/connect.d
+++ b/source/nijigenerate/viewport/common/mesheditor/tools/connect.d
@@ -19,6 +19,7 @@ import nijilive.core.dbg;
 import bindbc.opengl;
 import bindbc.imgui;
 //import std.stdio;
+import std.algorithm.searching : all;
 
 class ConnectTool : NodeSelect {
 
@@ -106,11 +107,22 @@ class ConnectTool : NodeSelect {
 class ToolInfoImpl(T: ConnectTool) : ToolInfoBase!(T) {
     override
     bool viewportTools(bool deformOnly, VertexToolMode toolMode, IncMeshEditorOne[Node] editors) {
-        if (!deformOnly)
+        if (deformOnly)
+            return false;
+
+        bool isDrawable = editors.keys.all!(k => cast(Drawable)k !is null);
+        if (isDrawable) {
             return super.viewportTools(deformOnly, toolMode, editors);
+        }
+
         return false;
     }
-    override bool canUse(bool deformOnly, Node[] targets) { return !deformOnly; }
+    override bool canUse(bool deformOnly, Node[] targets) {
+        if (deformOnly)
+            return false;
+
+        return targets.all!(k => cast(Drawable)k !is null);
+    }
     override VertexToolMode mode() { return VertexToolMode.Connect; };
     override string icon() { return "";}
     override string description() { return _("Edge Tool");}

--- a/source/nijigenerate/viewport/common/mesheditor/tools/grid.d
+++ b/source/nijigenerate/viewport/common/mesheditor/tools/grid.d
@@ -23,6 +23,7 @@ import std.array;
 import std.algorithm.searching: countUntil;
 import std.algorithm.mutation;
 import std.algorithm.sorting;
+import std.algorithm.searching : all;
 
 class GridTool : NodeSelect {
     GridActionID currentAction;
@@ -368,11 +369,22 @@ class ToolInfoImpl(T: GridTool) : ToolInfoBase!(T) {
 
     override
     bool viewportTools(bool deformOnly, VertexToolMode toolMode, IncMeshEditorOne[Node] editors) {
-        if (!deformOnly)
+        if (deformOnly)
+            return false;
+
+        bool isDrawable = editors.keys.all!(k => cast(Drawable)k !is null);
+        if (isDrawable) {
             return super.viewportTools(deformOnly, toolMode, editors);
+        }
+
         return false;
     }
-    override bool canUse(bool deformOnly, Node[] targets) { return !deformOnly; }
+    override bool canUse(bool deformOnly, Node[] targets) {
+        if (deformOnly)
+            return false;
+
+        return targets.all!(k => cast(Drawable)k !is null);
+    }
     override VertexToolMode mode() { return VertexToolMode.Grid; };
     override string icon() { return "";}
     override string description() { return _("Grid Vertex Tool");}

--- a/source/nijigenerate/viewport/common/mesheditor/tools/point.d
+++ b/source/nijigenerate/viewport/common/mesheditor/tools/point.d
@@ -161,39 +161,42 @@ class PointTool : NodeSelect {
                     changed = true;
                 }
 
-                // connect if there is a selected vertex
-                auto mesh = implDrawable.getMesh();
-                void connectVertex(ref MeshVertex* vertex) {
-                    if (vertex is null) return;
-
-                    // search last MeshAddAction to connect
-                    auto lastAddAction = incActionFindLast!VertexAddAction(3);
-                    if (lastAddAction is null || lastAddAction.vertices.length == 0) return;
-
-                    auto prevVertexIdx = impl.getVertexFromPoint(lastAddAction.vertices[$-1][$-1].position);
-                    auto prevVertex = impl.getVerticesByIndex([prevVertexIdx])[0];
-                    if (prevVertex == null) return;
-                    auto action = new MeshConnectAction(impl.getTarget().name, impl, mesh);
-                    impl.foreachMirror((uint axis) {
-                        MeshVertex* mPrev = impl.mirrorVertex(axis, prevVertex);
-                        MeshVertex* mSel  = impl.mirrorVertex(axis, vertex);
-
-                        if (mPrev !is null && mSel !is null) {
-                            action.connect(mPrev, mSel);
-                        }
-                    });
-                    impl.refreshMesh();
-                    action.updateNewState();
-                    incActionPush(action);
-
-                    changed = true;
-                }
-
                 MeshVertex* vertex;
                 addVertex(vertex);
+                
+                // TODO: consider refactoring this to IncMeshEditorOneDrawable?
+                if (implDrawable) {
+                    // connect if there is a selected vertex
+                    auto mesh = implDrawable.getMesh();
+                    void connectVertex(ref MeshVertex* vertex) {
+                        if (vertex is null) return;
 
-                if (autoConnect)
-                    connectVertex(vertex);
+                        // search last MeshAddAction to connect
+                        auto lastAddAction = incActionFindLast!VertexAddAction(3);
+                        if (lastAddAction is null || lastAddAction.vertices.length == 0) return;
+
+                        auto prevVertexIdx = impl.getVertexFromPoint(lastAddAction.vertices[$-1][$-1].position);
+                        auto prevVertex = impl.getVerticesByIndex([prevVertexIdx])[0];
+                        if (prevVertex == null) return;
+                        auto action = new MeshConnectAction(impl.getTarget().name, impl, mesh);
+                        impl.foreachMirror((uint axis) {
+                            MeshVertex* mPrev = impl.mirrorVertex(axis, prevVertex);
+                            MeshVertex* mSel  = impl.mirrorVertex(axis, vertex);
+
+                            if (mPrev !is null && mSel !is null) {
+                                action.connect(mPrev, mSel);
+                            }
+                        });
+                        impl.refreshMesh();
+                        action.updateNewState();
+                        incActionPush(action);
+
+                        changed = true;
+                    }
+
+                    if (autoConnect)
+                        connectVertex(vertex);
+                }
             }
         }
 


### PR DESCRIPTION
fix(mesh-editor): make ConnectTool type-safe to prevent BezierDeform segfault
- Updated ToolInfoImpl to check that all targets are Drawable before enabling the tool.
- `canUse` and `viewportTools` now return false for non-Drawable or deformOnly targets.
- Prevents segmentation faults when BezierDeform nodes are present in the selection.
 
fix(mesh-editor): restrict GridTool and PointTool to Drawable nodes only
- Updated GridTool `viewportTools` and `canUse` to check for Drawable nodes explicitly.
- Prevents crashes when tool is activated on non-Drawable targets.
- hot fix PointTool so vertex auto-connect logic only runs when `implDrawable` is valid.
