### PR TITLE
refactor: render armed parameters in-place in ParametersPanel

### DIFF
--- a/source/nijigenerate/panels/parameters.d
+++ b/source/nijigenerate/panels/parameters.d
@@ -739,24 +739,19 @@ protected:
         igEndChild();
 
         if (igBeginChild("ParametersList", ImVec2(0, -36))) {
-            
-            // Always render the currently armed parameter on top
-            if (incArmedParameter()) {
-                incParameterView!true(incArmedParameterIdx(), incArmedParameter(), &grabParam, false, parameters);
-            }
 
             // Render other parameters
             void displayParameters(Parameter[] targetParams, bool hideChildren) {
                 foreach(i, ref param; targetParams) {
-                    if (incArmedParameter() == param) continue;
+                    // keep armed parameter rendered in place
                     if (hideChildren && (cast(ExParameter)param) && (cast(ExParameter)param).parent) continue;
                     import std.algorithm.searching : canFind;
                     ExParameterGroup group = cast(ExParameterGroup)param;
-                    bool found = filter.length == 0 || param.indexableName.canFind(filter);
+                    bool found = filter.length == 0 || param.indexableName.canFind(filter) || (incArmedParameter() == param);
                     if (group) {
                         foreach (ix, ref child; group.children) {
-                            if (incArmedParameter() == child) continue;
-                            if (child.indexableName.canFind(filter))
+                            // keep armed child parameter rendered in place
+                            if (child.indexableName.canFind(filter) || (incArmedParameter() == child))
                                 found = true;
                         }
                     }
@@ -797,11 +792,7 @@ protected:
                                 // Render children if open
                                 if (open) {
                                     foreach(ix, ref child; group.children) {
-
-                                        // Skip armed param
-                                        if (incArmedParameter() == child) continue;
-                                        if (child.indexableName.canFind(filter)) {
-                                            // Otherwise render it
+                                        if (child.indexableName.canFind(filter) || (incArmedParameter() == child)) {
                                             incParameterView(ix, child, &grabParam, false, group.children, group.color);
                                         }
                                     }


### PR DESCRIPTION
## Summary
Previously, the `ParametersPanel` always rendered the currently armed parameter at the top of the list.  
This is no longer necessary, because we now have a dedicated `ArmedParametersPanel` window.

This PR changes the behavior so that armed parameters are displayed in their original positions within the list.  
This improves the user experience by preserving the natural parameter order.

## Details
- Armed parameters are no longer pinned to the top of `ParametersPanel`.
- Armed parameters are rendered in-place alongside other parameters.
- Filtering now keeps armed parameters visible even if the filter would otherwise hide them.

## Motivation
- Users expecting the old "pinned" behavior can use the separate `ArmedParametersPanel`.
- Reduces redundancy and confusion in the UI.
- Enhances clarity and usability for parameter management.
