### PR TITLE
fix: disable TLS for macOS until OpenSSL 3.x support

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -14,6 +14,13 @@ dependency "nijilive" version="~>0.0.1"
 dependency "mcp" version="~>1.0.1"
 dependency "vibe-d:http" version="~>0.10.0"
 
+// Disable tls until vibe upstream supports openssl 3.x
+// https://github.com/vibe-d/vibe.d/issues/2648
+// homebrew openssl 1.1 is deprecated, may not work on macOS arm64
+// https://formulae.brew.sh/formula/openssl@1.1
+dependency "vibe-stream:tls" version="~>1.0"
+subConfiguration "vibe-stream:tls" "notls"
+
 targetPath "out/"
 workingDirectory "out/"
 dflags "-mscrtlib=msvcrt" platform="windows-ldc"


### PR DESCRIPTION
On macOS, nightly builds fail to compile because `/usr/local/opt/openssl@1.1` only contains x86 or arm libraries, that affected by the compilation environment, and Homebrew has deprecated `openssl@1.1`. The recommended approach is to use OpenSSL 3.x. 

 However, upstream only provides static linking versions. Static linking also requires careful consideration of licensing (https://openssl-library.org/source/license/index.html).  

To avoid compilation issues, TLS is temporarily disabled (`notls`).

```
ld: warning: search path '/usr/local/opt/openssl@1.1/lib' not found
ld: warning: search path '/usr/local/opt/openssl/lib' not found
ld: warning: ignoring file '/opt/homebrew/Cellar/openssl@3/3.5.2/lib/libssl.3.dylib': found architecture 'arm64', required architecture 'x86_64'
ld: warning: ignoring file '/opt/homebrew/Cellar/openssl@3/3.5.2/lib/libcrypto.3.dylib': found architecture 'arm64', required architecture 'x86_64'
ld: warning: no platform load command found in '/Users/runner/.dub/cache/nijigenerate/~main/build/osx-nightly-$DFLAGS-5ZPQYvhVvaiqWFE8SDFtwQ/nijigenerate.o', assuming: macOS
ld: warning: no platform load command found in '../../../.dub/cache/i18n-d/1.0.2/build/library-$DFLAGS-oc3TBeBuGd5K3R9Y9z4I-g/libi18n-d.a[2](i18n.culture.o)', assuming: macOS
ld: warning: no platform load command found in '../../../.dub/cache/i18n-d/1.0.2/build/library-$DFLAGS-oc3TBeBuGd5K3R9Y9z4I-g/libi18n-d.a[3](i18n.mo.o)', assuming: macOS
ld: warning: no platform load command found in '../../../.dub/cache/i18n-d/1.0.2/build/library-$DFLAGS-oc3TBeBuGd5K3R9Y9z4I-g/libi18n-d.a[4](i18n.o)', assuming: macOS
ld: warning: no platform load command found in '../../../.dub/cache/i18n-d/1.0.2/build/library-$DFLAGS-oc3TBeBuGd5K3R9Y9z4I-g/libi18n-d.a[5](i18n.tr.o)', assuming: macOS
ld: warning: no platform load command found in '../../../.dub/cache/i2d-imgui/0.8.0/build/dynamic_dynamicCRT-$DFLAGS-q2J5iIUb9g5pUtcQRuh33A/libi2d-imgui.a[2](bindbc.imgui.bind.imgui.o)', assuming: macOS
```
See GitHub workflow runs:

main: https://github.com/r888800009/nijigenerate/actions/runs/17513609505/job/49748370830

PR: https://github.com/r888800009/nijigenerate/actions/runs/17513699396/job/49748579176

Compiled log on Arm macbook is as follows:
```
ld: warning: ignoring file '/usr/local/opt/openssl@1.1/lib/libssl.dylib': found architecture 'x86_64', required architecture 'arm64'
ld: warning: ignoring file '/usr/local/opt/openssl@1.1/lib/libcrypto.dylib': found architecture 'x86_64', required architecture 'arm64'
Undefined symbols for architecture arm64:
  "_ASN1_STRING_to_UTF8", referenced from:
      __D4vibe6stream7openssl14verifyCertNameFNePS6deimosQBk5types7x509_stiIAabZ11check_valueMFPSQBvQDb4asn114asn1_string_stiZb in libvibe-d_tls.a[3](vibe.stream.openssl.o)
  "_BIO_clear_flags", referenced from:
      _onBioNew in libvibe-d_tls.a[3](vibe.stream.openssl.o)
      _onBioFree in libvibe-d_tls.a[3](vibe.stream.openssl.o)
  "_BIO_get_data", referenced from:
      __D4vibe6stream7openssl9onBioReadUNbNfPS6deimosQBg3bio6bio_stPxaiZ18__lambda_L1419_C17MFNbNeZCQDnQDlQDh13OpenSSLStream in libvibe-d_tls.a[3](vibe.stream.openssl.o)
      __D4vibe6stream7openssl10onBioWriteUNbNfPS6deimosQBi3bio6bio_stPxaiZ18__lambda_L1433_C17MFNbNeZCQDpQDnQDj13OpenSSLStream in libvibe-d_tls.a[3](vibe.stream.openssl.o)
      __D4vibe6stream7openssl9onBioCtrlUNbNfPS6deimosQBg3bio6bio_stilPvZ18__lambda_L1445_C17MFNbNeZCQDnQDlQDh13OpenSSLStream in libvibe-d_tls.a[3](vibe.stream.openssl.o)
  "_BIO_get_new_index", referenced from:
```