### PR TITLE
Add MeshGroup/Mask alpha input and mapping for AutoMesh

### DIFF
--- a/source/nijigenerate/viewport/package.d
+++ b/source/nijigenerate/viewport/package.d
@@ -11,6 +11,7 @@ import nijilive;
 import nijilive.core.animation.player;
 import nijigenerate.project;
 public import nijigenerate.viewport.base;
+import nijigenerate.viewport.vertex.automesh.alpha_provider : alphaPreviewDisposeTexture;
 
 private {
 
@@ -21,6 +22,10 @@ private {
         void onEditModeChanged(EditMode mode) {
             incViewport.onEditModeChanged(mode);
             incViewport.present();
+            // Dispose alpha preview texture when exiting VertexEdit
+            if (mode != EditMode.VertexEdit) {
+                alphaPreviewDisposeTexture();
+            }
         }
 
         void onCameraFocused(float focus, vec2 pos) {

--- a/source/nijigenerate/viewport/vertex/automesh/alpha_provider.d
+++ b/source/nijigenerate/viewport/vertex/automesh/alpha_provider.d
@@ -1,0 +1,383 @@
+module nijigenerate.viewport.vertex.automesh.alpha_provider;
+
+/**
+ * Alpha-only input abstraction for AutoMesh.
+ *
+ * Providers expose a CPU-readable 8-bit alpha buffer and the world-space
+ * rectangle that was projected to generate the buffer.
+ */
+interface IAlphaProvider {
+    int width();
+    int height();
+    const(ubyte)* alphaPtr();
+    RectF boundsWorld();
+    void dispose();
+}
+
+/// Simple rectangle type (world-space bounds)
+struct RectF {
+    float x;
+    float y;
+    float w;
+    float h;
+}
+
+/// Options for projection-based alpha providers
+struct ProjectionOptions {
+    int padding = 8;          // extra pixels around bounds
+    int targetWidth = 0;      // 0 => auto from bounds
+    int targetHeight = 0;     // 0 => auto from bounds
+}
+
+import nijilive; // Part, Texture, Node, Texture, DynamicComposite, Puppet, GL helpers
+import nijigenerate.project : incActivePuppet;
+import nijigenerate.core.window : incResetClearColor;
+import std.algorithm : min, max;
+import std.exception : enforce;
+import bindbc.imgui;
+import nijigenerate.project : incSelectedNodes;
+import nijigenerate.widgets.texture : incTextureSlot;
+import std.conv : to;
+import std.math : floor, ceil, isNaN;
+
+/**
+ * PartAlphaProvider: wraps a Part's texture alpha channel as AutoMesh input.
+ *
+ * Note: This mirrors the current behavior in ContourAutoMeshProcessor, but
+ * provides it via a unified provider interface.
+ */
+final class PartAlphaProvider : IAlphaProvider {
+    private ubyte[] _alpha;
+    private int _w, _h;
+    private RectF _bounds;
+
+    this(Part part) {
+        if (part is null || part.textures.length == 0 || part.textures[0] is null) {
+            _w = _h = 0;
+            _bounds = RectF(0, 0, 0, 0);
+            return;
+        }
+        auto texture = part.textures[0];
+        _w = texture.width;
+        _h = texture.height;
+        // Bounds: local texture size around origin; world mapping is applied in downstream
+        _bounds = RectF(0, 0, cast(float)_w, cast(float)_h);
+
+        ubyte[] data = texture.getTextureData(); // RGBA, row-major
+        if (data.length >= cast(size_t)_w * _h * 4) {
+            _alpha.length = cast(size_t)_w * _h;
+            size_t p = 0;
+            foreach (i; 0 .. _w * _h) {
+                // pick A component (assuming RGBA order)
+                _alpha[i] = data[p + 3];
+                p += 4;
+            }
+        }
+    }
+
+    override int width() { return _w; }
+    override int height() { return _h; }
+    override const(ubyte)* alphaPtr() { return _alpha.ptr; }
+    override RectF boundsWorld() { return _bounds; }
+    override void dispose() { _alpha.length = 0; }
+}
+
+/**
+ * MeshGroupAlphaProvider (stub): projection-based alpha provider for MeshGroup
+ * and other composite nodes. This class defines the interface and basic state,
+ * and can be extended to perform offscreen rendering and readback.
+ */
+final class MeshGroupAlphaProvider : IAlphaProvider {
+    private ubyte[] _alpha;
+    private int _w, _h;
+    private RectF _bounds;
+
+    this(Node meshGroup, ProjectionOptions opt = ProjectionOptions.init) {
+        if (meshGroup is null) {
+            _w = _h = 0; _bounds = RectF(0,0,0,0); return;
+        }
+        auto puppet = meshGroup.puppet is null ? incActivePuppet() : meshGroup.puppet;
+        enforce(puppet !is null, "No active puppet for MeshGroupAlphaProvider");
+
+        // DynamicComposite を使って対象ノードのみをオフスクリーン投影
+        auto r = projectAlphaExec([meshGroup], puppet, opt);
+        _w = r.w; _h = r.h; _bounds = r.bounds; _alpha = r.alpha;
+    }
+
+    override int width() { return _w; }
+    override int height() { return _h; }
+    override const(ubyte)* alphaPtr() { return _alpha.ptr; }
+    override RectF boundsWorld() { return _bounds; }
+    override void dispose() { _alpha.length = 0; }
+}
+
+/**
+ * GenericProjectionAlphaProvider: 任意のノード配列を対象に、暫定的に現在の
+ * ビューポートから A をダンプして返す（後続でサブグラフ限定投影に差し替え）。
+ */
+final class GenericProjectionAlphaProvider : IAlphaProvider {
+    private ubyte[] _alpha;
+    private int _w, _h;
+    private RectF _bounds;
+
+    this(Node[] targets, ProjectionOptions opt = ProjectionOptions.init) {
+        auto puppet = incActivePuppet();
+        enforce(puppet !is null, "No active puppet for GenericProjectionAlphaProvider");
+        auto r = projectAlphaExec(targets, puppet, opt);
+        _w = r.w; _h = r.h; _bounds = r.bounds; _alpha = r.alpha;
+    }
+
+    override int width() { return _w; }
+    override int height() { return _h; }
+    override const(ubyte)* alphaPtr() { return _alpha.ptr; }
+    override RectF boundsWorld() { return _bounds; }
+    override void dispose() { _alpha.length = 0; }
+}
+
+private struct ProjectionResult {
+    ubyte[] alpha;
+    int w;
+    int h;
+    RectF bounds;
+}
+
+private ProjectionResult projectAlphaExec(Node[] targets, Puppet puppet, ProjectionOptions opt) {
+    ProjectionResult res;
+
+    if (targets.length == 0 || puppet is null) {
+        res.w = res.h = 0;
+        res.bounds = RectF(0,0,0,0);
+        return res;
+    }
+
+    // Collect drawables under targets with coverOthers-aware traversal
+    Drawable[] drawables;
+    void findSubDrawable(Node n) {
+        if (n is null) return;
+        // If node covers others, we only consider its children
+        if (n.coverOthers()) {
+            foreach (child; n.children) findSubDrawable(child);
+            return;
+        }
+        // Composite handling
+        if (auto comp = cast(Composite)n) {
+            if (comp.propagateMeshGroup) {
+                foreach (child; n.children) findSubDrawable(child);
+            }
+            // Do not traverse further under non-propagating composites
+            return;
+        }
+        // Drawable is a terminal we want; also traverse children
+        if (auto d = cast(Drawable)n) {
+            drawables ~= d;
+            foreach (child; n.children) findSubDrawable(child);
+            return;
+        }
+        // Plain Node: stop here (exclude descendants)
+        return;
+    }
+    foreach (t; targets) findSubDrawable(t);
+    if (drawables.length == 0) {
+        res.w = res.h = 0; res.bounds = RectF(0,0,0,0); return res;
+    }
+
+    // Compute union bounds from transformed vertices
+    float minX = float.infinity, minY = float.infinity;
+    float maxX = -float.infinity, maxY = -float.infinity;
+    foreach (d; drawables) {
+        auto m = d.getDynamicMatrix();
+        auto verts = d.vertices;
+        if (verts.length == 0) continue;
+        if (d.deformation.length != verts.length) d.refreshDeform();
+        foreach (i, v; verts) {
+            vec2 wp = (m * vec4(v + d.deformation[i], 0, 1)).xy;
+            if (wp.x < minX) minX = wp.x;
+            if (wp.y < minY) minY = wp.y;
+            if (wp.x > maxX) maxX = wp.x;
+            if (wp.y > maxY) maxY = wp.y;
+        }
+    }
+    if (!(minX < maxX && minY < maxY)) { res.w = res.h = 0; res.bounds = RectF(0,0,0,0); return res; }
+
+    int pad = opt.padding;
+    int w = cast(int)ceil(maxX - minX) + pad * 2;
+    int h = cast(int)ceil(maxY - minY) + pad * 2;
+    if (opt.targetWidth > 0) w = opt.targetWidth;
+    if (opt.targetHeight > 0) h = opt.targetHeight;
+    if (w <= 0 || h <= 0) { res.w = res.h = 0; res.bounds = RectF(0,0,0,0); return res; }
+
+    // Output buffer
+    ubyte[] outA; outA.length = cast(size_t)w * h; outA[] = 0;
+
+    // Helper: composite alpha (over)
+    auto compOver = (ubyte dst, ubyte src) {
+        // out = src + dst*(1-src)
+        uint s = src;
+        uint d = dst;
+        uint o_ = s + (d * (255 - s)) / 255;
+        return cast(ubyte)o_;
+    };
+
+    // Rasterize each drawable
+    foreach (d; drawables) {
+        auto m = d.getDynamicMatrix();
+        auto verts = d.vertices;
+        if (verts.length == 0) continue;
+        if (d.deformation.length != verts.length) d.refreshDeform();
+
+        // Precompute world positions
+        vec2[] wpos; wpos.length = verts.length;
+        foreach (i, v; verts) {
+            wpos[i] = (m * vec4(v + d.deformation[i], 0, 1)).xy;
+        }
+
+        // Mesh data
+        auto mesh = d.getMesh();
+        if (mesh.indices.length == 0 || mesh.vertices.length == 0) continue;
+
+        // Texture alpha if Part; otherwise no contribution (alpha 0)
+        ubyte[] texData;
+        int tw = 0, th = 0;
+        bool sampleTex = false;
+        if (auto p = cast(Part)d) {
+            auto tex = p.textures[0];
+            if (tex !is null) {
+                tw = tex.width; th = tex.height;
+                texData = tex.getTextureData();
+                sampleTex = true;
+            }
+        }
+
+        // Rasterize triangles
+        foreach (tri; 0 .. mesh.indices.length/3) {
+            ushort i0 = mesh.indices[tri*3+0];
+            ushort i1 = mesh.indices[tri*3+1];
+            ushort i2 = mesh.indices[tri*3+2];
+
+            vec2 A = wpos[i0];
+            vec2 B = wpos[i1];
+            vec2 C = wpos[i2];
+
+            // Convert to pixel space
+            auto toPix = (vec2 p) {
+                float fx = (p.x - minX) + pad;
+                float fy = (p.y - minY) + pad;
+                return vec2(fx, fy);
+            };
+            vec2 Ap = toPix(A), Bp = toPix(B), Cp = toPix(C);
+
+            int minPX = cast(int)floor(min(Ap.x, min(Bp.x, Cp.x)));
+            int maxPX = cast(int)ceil (max(Ap.x, max(Bp.x, Cp.x)));
+            int minPY = cast(int)floor(min(Ap.y, min(Bp.y, Cp.y)));
+            int maxPY = cast(int)ceil (max(Ap.y, max(Bp.y, Cp.y)));
+            if (maxPX < 0 || maxPY < 0 || minPX >= w || minPY >= h) continue;
+            minPX = max(minPX, 0); minPY = max(minPY, 0);
+            maxPX = min(maxPX, w-1); maxPY = min(maxPY, h-1);
+
+            // Barycentric setup
+            float denom = (Bp.y - Cp.y)*(Ap.x - Cp.x) + (Cp.x - Bp.x)*(Ap.y - Cp.y);
+            if (denom == 0) continue;
+
+            // UVs
+            vec2 uv0, uv1, uv2;
+            bool hasUV = mesh.uvs.length == mesh.vertices.length && sampleTex;
+            if (hasUV) {
+                uv0 = mesh.uvs[i0]; uv1 = mesh.uvs[i1]; uv2 = mesh.uvs[i2];
+            }
+
+            foreach (py; minPY .. maxPY+1) {
+                foreach (px; minPX .. maxPX+1) {
+                    vec2 P = vec2(px + 0.5f, py + 0.5f);
+                    float w1 = ((Bp.y - Cp.y)*(P.x - Cp.x) + (Cp.x - Bp.x)*(P.y - Cp.y)) / denom;
+                    float w2 = ((Cp.y - Ap.y)*(P.x - Cp.x) + (Ap.x - Cp.x)*(P.y - Cp.y)) / denom;
+                    float w3 = 1 - w1 - w2;
+                    if (w1 < 0 || w2 < 0 || w3 < 0) continue;
+
+                    ubyte a = 0;
+                    if (sampleTex && texData.length >= cast(size_t)tw*th*4 && hasUV) {
+                        vec2 uv = uv0 * w1 + uv1 * w2 + uv2 * w3;
+                        // clamp 0..1
+                        float u = uv.x; if (isNaN(u)) u = 0; u = u < 0 ? 0 : (u > 1 ? 1 : u);
+                        float v = uv.y; if (isNaN(v)) v = 0; v = v < 0 ? 0 : (v > 1 ? 1 : v);
+                        int tx = cast(int)floor(u * (tw - 1));
+                        int ty = cast(int)floor(v * (th - 1));
+                        size_t idx = cast(size_t)((ty*tw + tx) * 4 + 3);
+                        a = texData[idx];
+                    }
+
+                    size_t o = cast(size_t)(py*w + px);
+                    outA[o] = compOver(outA[o], a);
+                }
+            }
+        }
+    }
+
+    res.w = w; res.h = h; res.alpha = outA;
+    res.bounds = RectF(minX, minY, maxX - minX, maxY - minY);
+    return res;
+}
+
+// Unified alpha preview widget state and renderer
+struct AlphaPreviewState { bool show; }
+
+// Global preview texture cache and signature
+private Texture gAlphaPrevTex;
+private int gAlphaPrevW, gAlphaPrevH;
+private string gAlphaPrevSig;
+
+package(nijigenerate) void alphaPreviewDisposeTexture() {
+    if (gAlphaPrevTex !is null) {
+        gAlphaPrevTex.dispose();
+        gAlphaPrevTex = null;
+    }
+    gAlphaPrevW = 0; gAlphaPrevH = 0; gAlphaPrevSig = null;
+}
+
+void alphaPreviewWidget(ref AlphaPreviewState state, ImVec2 size = ImVec2(192, 192)) {
+    igCheckbox("show_alpha_preview", &state.show);
+    if (!state.show) return;
+
+    auto nodes = incSelectedNodes();
+    // Build selection signature
+    string sig;
+    foreach (n; nodes) sig ~= to!string(n.uuid) ~ ":";
+
+    if (sig != gAlphaPrevSig) {
+        gAlphaPrevSig = sig;
+        IAlphaProvider provider = null;
+        scope(exit) if (provider) provider.dispose();
+        if (nodes.length == 1) {
+            if (auto part = cast(Part)nodes[0]) provider = new PartAlphaProvider(part);
+            else provider = new MeshGroupAlphaProvider(nodes[0]);
+        } else if (nodes.length > 1) {
+            provider = new GenericProjectionAlphaProvider(nodes);
+        }
+
+        if (provider !is null && provider.width() > 0 && provider.height() > 0) {
+            int w = provider.width();
+            int h = provider.height();
+            const(ubyte)* ap = provider.alphaPtr();
+            if (gAlphaPrevTex !is null && (gAlphaPrevW != w || gAlphaPrevH != h)) {
+                gAlphaPrevTex.dispose();
+                gAlphaPrevTex = null;
+            }
+            if (gAlphaPrevTex is null) {
+                gAlphaPrevTex = new Texture(w, h);
+                gAlphaPrevW = w; gAlphaPrevH = h;
+            }
+            ubyte[] rgba = new ubyte[w*h*4];
+            foreach (i; 0 .. w*h) {
+                ubyte a = ap[i];
+                rgba[i*4+0] = 0;
+                rgba[i*4+1] = 0;
+                rgba[i*4+2] = 0;
+                rgba[i*4+3] = a;
+            }
+            gAlphaPrevTex.setData(rgba);
+        }
+    }
+
+    if (gAlphaPrevTex !is null) {
+        incTextureSlot("Alpha", gAlphaPrevTex, size);
+    }
+}

--- a/source/nijigenerate/viewport/vertex/automesh/alpha_provider.d
+++ b/source/nijigenerate/viewport/vertex/automesh/alpha_provider.d
@@ -99,7 +99,7 @@ final class MeshGroupAlphaProvider : IAlphaProvider {
         auto puppet = meshGroup.puppet is null ? incActivePuppet() : meshGroup.puppet;
         enforce(puppet !is null, "No active puppet for MeshGroupAlphaProvider");
 
-        // DynamicComposite を使って対象ノードのみをオフスクリーン投影
+        // Use DynamicComposite to render only target nodes offscreen
         auto r = projectAlphaExec([meshGroup], puppet, opt);
         _w = r.w; _h = r.h; _bounds = r.bounds; _alpha = r.alpha;
     }
@@ -112,8 +112,8 @@ final class MeshGroupAlphaProvider : IAlphaProvider {
 }
 
 /**
- * GenericProjectionAlphaProvider: 任意のノード配列を対象に、暫定的に現在の
- * ビューポートから A をダンプして返す（後続でサブグラフ限定投影に差し替え）。
+ * GenericProjectionAlphaProvider: For arbitrary nodes, temporarily dump alpha (A)
+ * from current viewport; replace with subgraph-limited projection later.
  */
 final class GenericProjectionAlphaProvider : IAlphaProvider {
     private ubyte[] _alpha;

--- a/source/nijigenerate/viewport/vertex/automesh/common.d
+++ b/source/nijigenerate/viewport/vertex/automesh/common.d
@@ -1,0 +1,89 @@
+module nijigenerate.viewport.vertex.automesh.common;
+
+import nijilive.core;
+import nijigenerate.core.cv.image;
+import nijigenerate.viewport.common.mesh;
+import nijigenerate.viewport.vertex.automesh.alpha_provider;
+import inmath;
+
+struct AlphaInput {
+    Image img;        // RGBA image where A contains the alpha mask (may be null when constructed from provider only)
+    int w;
+    int h;
+    bool fromProvider;
+    vec2 providerWorldCenter; // valid when fromProvider
+}
+
+AlphaInput alphaInputFromProvider(IAlphaProvider provider) {
+    AlphaInput ai;
+    ai.w = provider.width();
+    ai.h = provider.height();
+    ai.fromProvider = true;
+    auto b = provider.boundsWorld();
+    ai.providerWorldCenter = vec2(b.x + b.w * 0.5f, b.y + b.h * 0.5f);
+    return ai;
+}
+
+AlphaInput alphaInputFromProviderWithImage(IAlphaProvider provider) {
+    AlphaInput ai = alphaInputFromProvider(provider);
+    if (ai.w > 0 && ai.h > 0) {
+        ai.img = new Image(ai.w, ai.h, ImageFormat.IF_RGB_ALPHA);
+        ai.img.data[] = 0;
+        const(ubyte)* ap = provider.alphaPtr();
+        foreach (i; 0 .. ai.w * ai.h) ai.img.data[i * 4 + 3] = ap[i];
+    }
+    return ai;
+}
+
+AlphaInput getAlphaInput(Drawable target) {
+    AlphaInput ai;
+    if (auto part = cast(Part)target) {
+        auto tex = part.textures[0];
+        if (tex is null) return ai;
+        ubyte[] data = tex.getTextureData();
+        ai.img = new Image(tex.width, tex.height, ImageFormat.IF_RGB_ALPHA);
+        ai.w = tex.width;
+        ai.h = tex.height;
+        ai.img.data[] = 0;
+        // Copy full RGBA so downstream that expects RGB can work, but A is the only channel used
+        if (data.length == ai.img.data.length) ai.img.data[] = data[];
+        else {
+            // Fallback: copy alpha only if layout differs
+            foreach (i; 0 .. ai.w*ai.h) ai.img.data[i*4+3] = data[i*4+3];
+        }
+        ai.fromProvider = false;
+    } else {
+        auto provider = new MeshGroupAlphaProvider(target);
+        scope(exit) provider.dispose();
+        ai.w = provider.width();
+        ai.h = provider.height();
+        if (ai.w <= 0 || ai.h <= 0) return ai;
+        ai.img = new Image(ai.w, ai.h, ImageFormat.IF_RGB_ALPHA);
+        ai.img.data[] = 0;
+        const(ubyte)* ap = provider.alphaPtr();
+        foreach (i; 0 .. ai.w*ai.h) ai.img.data[i*4 + 3] = ap[i];
+        auto b = provider.boundsWorld();
+        ai.providerWorldCenter = vec2(b.x + b.w * 0.5f, b.y + b.h * 0.5f);
+        ai.fromProvider = true;
+    }
+    return ai;
+}
+
+vec2 alphaImageCenter(AlphaInput ai) {
+    return vec2(ai.w / 2, ai.h / 2);
+}
+
+void mapImageCenteredMeshToTargetLocal(ref IncMesh mesh, Drawable target, AlphaInput ai) {
+    // mesh vertices are expected to be relative to image center (imgCenter at (0,0))
+    if (ai.fromProvider) {
+        mat4 inv = target.transform.matrix.inverse;
+        foreach (v; mesh.vertices) {
+            vec2 worldPos = v.position + ai.providerWorldCenter;
+            v.position = (inv * vec4(worldPos, 0, 1)).xy;
+        }
+    } else {
+        if (auto dcomposite = cast(DynamicComposite)target) {
+            foreach (vertex; mesh.vertices) vertex.position += dcomposite.textureOffset;
+        }
+    }
+}

--- a/source/nijigenerate/viewport/vertex/automesh/contours.d
+++ b/source/nijigenerate/viewport/vertex/automesh/contours.d
@@ -14,6 +14,8 @@ import std.algorithm.iteration: map, reduce;
 //import std.stdio;
 import std.array;
 import bindbc.imgui;
+import nijigenerate.viewport.vertex.automesh.alpha_provider;
+import nijigenerate.project : incSelectedNodes;
 
 class ContourAutoMeshProcessor : AutoMeshProcessor {
     float SAMPLING_STEP = 32;
@@ -23,7 +25,124 @@ class ContourAutoMeshProcessor : AutoMeshProcessor {
     float MAX_DISTANCE = -1;
     float[] SCALES = [1, 1.1, 0.9, 0.7, 0.4, 0.2, 0.1];
     string presetName;
-public:
+    // Unified alpha preview state
+    private AlphaPreviewState _alphaPreview;
+    public:
+    /// IAlphaProvider から直接オートメッシュを生成する拡張版
+    IncMesh autoMesh(IAlphaProvider provider, IncMesh mesh, bool mirrorHoriz = false, float axisHoriz = 0, bool mirrorVert = false, float axisVert = 0)
+    {
+        if (provider is null || provider.width() == 0 || provider.height() == 0)
+            return mesh;
+
+        // 入力アルファを Image にパックして既存パイプラインを流用（A チャンネルのみ使用）
+        int w = provider.width();
+        int h = provider.height();
+        auto img = new Image(w, h, ImageFormat.IF_RGB_ALPHA);
+        // RGBA 配列をクリアし、A に provider の値を書き込む
+        img.data[] = 0;
+        const(ubyte)* aptr = provider.alphaPtr();
+        if (aptr !is null) {
+            foreach (i; 0 .. w * h) {
+                img.data[i * 4 + 3] = aptr[i];
+            }
+        }
+
+        // A チャンネルのみを二値化
+        auto gray = img.sliced[0 .. $, 0 .. $, 3];
+        auto imbin = gray;
+        foreach (y; 0 .. imbin.shape[0]) {
+            foreach (x; 0 .. imbin.shape[1]) {
+                imbin[y, x] = imbin[y, x] < cast(ubyte)maskThreshold ? 0 : 255;
+            }
+        }
+
+        mesh.clear();
+        vec2 imgCenter = vec2(w / 2, h / 2);
+
+        vec2i[][] foundContours;
+        ContourHierarchy[] hierarchy;
+        findContours(imbin, foundContours, hierarchy, RetrievalMode.EXTERNAL, ApproximationMethod.SIMPLE);
+
+        // 既存パスのローカル関数を再利用（コンパイラが重複定義を許容するよう最小限の重複）
+        auto contoursToVec2s(ContourType)(ref ContourType contours) {
+            vec2[] result;
+            foreach (p; contours) {
+                result ~= vec2(p.x, p.y);
+            }
+            return result;
+        }
+        auto calcMoment(vec2[] contour) {
+            auto moment = contour.reduce!((a, b) { return a + b; })();
+            return moment / contour.length;
+        }
+        auto scaling(vec2[] contour, vec2 moment, float scale, int erode_dilate) {
+            return contour.map!((c) { return (c - moment) * scale + moment; }).array;
+        }
+        auto resampling(vec2[] contour, double rate, bool mirrorHoriz, float axisHoriz, bool mirrorVert, float axisVert) {
+            vec2[] sampled;
+            ulong base = 0;
+            if (mirrorHoriz) {
+                float minDistance = -1;
+                foreach (i, vertex; contour) {
+                    if (minDistance < 0 || vertex.x - axisHoriz < minDistance) {
+                        base = i;
+                        minDistance = vertex.x - axisHoriz;
+                    }
+                }
+            }
+            sampled ~= contour[base];
+            float side = 0;
+            foreach (idx; 1 .. contour.length) {
+                vec2 prev = sampled[$ - 1];
+                vec2 c = contour[(idx + base) % contour.length];
+                if ((c - prev).lengthSquared > rate * rate) {
+                    if (mirrorHoriz) {
+                        if (side == 0) {
+                            side = sign(c.x - axisHoriz);
+                        } else if (sign(c.x - axisHoriz) != side) {
+                            continue;
+                        }
+                    }
+                    sampled ~= c;
+                }
+            }
+            return sampled;
+        }
+
+        foreach (contour; foundContours) {
+            auto contourVec = contoursToVec2s(contour);
+            if (contourVec.length == 0)
+                continue;
+            float[] scales = SCALES;
+            auto moment = calcMoment(contourVec);
+            if (MAX_DISTANCE < 0)
+                MAX_DISTANCE = SAMPLING_STEP * 2;
+            foreach (double scale; scales) {
+                double samplingRate = SAMPLING_STEP;
+                samplingRate = min(MAX_DISTANCE / scale, scale > 0 ? samplingRate / (scale * scale) : 1);
+                auto contour2 = resampling(contourVec, samplingRate, mirrorHoriz, imgCenter.x + axisHoriz, mirrorVert, imgCenter.y + axisVert);
+                auto contour3 = scaling(contour2, moment, scale, 0);
+                if (mirrorHoriz) {
+                    auto flipped = contour3.map!((a) { return vec2(imgCenter.x + axisHoriz - (a.x - imgCenter.x - axisHoriz), a.y); })();
+                    foreach (f; flipped) {
+                        auto scaledContourVec = scaling(contourVec, moment, scale, 0);
+                        auto index = scaledContourVec.map!((a) { return (a - f).lengthSquared; }).minIndex();
+                        contour3 ~= scaledContourVec[index];
+                    }
+                }
+                foreach (vec2 c; contour3) {
+                    if (mesh.vertices.length > 0) {
+                        auto minDistance = mesh.vertices.map!((v) { return ((c - imgCenter) - v.position).length; }).reduce!((a, b) { return a < b ? a : b; });
+                        if (minDistance > MIN_DISTANCE)
+                            mesh.vertices ~= new MeshVertex(c - imgCenter, []);
+                    } else {
+                        mesh.vertices ~= new MeshVertex(c - imgCenter, []);
+                    }
+                }
+            }
+        }
+        return mesh.autoTriangulate();
+    }
     override IncMesh autoMesh(Drawable target, IncMesh mesh, bool mirrorHoriz = false, float axisHoriz = 0, bool mirrorVert = false, float axisVert = 0) {
         if (MAX_DISTANCE < 0)
             MAX_DISTANCE = SAMPLING_STEP * 2;
@@ -74,8 +193,21 @@ public:
             return sampled;
         }
         Part part = cast(Part)target;
-        if (!part)
-            return mesh;
+        if (!part) {
+            // 非Part: ProviderのAから前段処理→ターゲットローカルへ座標補正
+            auto provider = new MeshGroupAlphaProvider(target);
+            scope(exit) provider.dispose();
+            auto result = this.autoMesh(provider, mesh, mirrorHoriz, axisHoriz, mirrorVert, axisVert);
+
+            auto b = provider.boundsWorld();
+            vec2 worldCenter = vec2(b.x + b.w * 0.5f, b.y + b.h * 0.5f);
+            mat4 inv = target.transform.matrix.inverse;
+            foreach (v; result.vertices) {
+                vec2 worldPos = v.position + worldCenter;
+                v.position = (inv * vec4(worldPos, 0, 1)).xy;
+            }
+            return result;
+        }
         Texture texture = part.textures[0];
         if (!texture)
             return mesh;
@@ -133,6 +265,14 @@ public:
             }
         }
         return mesh.autoTriangulate();
+    }
+
+    /// 任意ノード配列を対象にプロジェクションAからメッシュ化（Mask/Shape 含む）
+    IncMesh autoMesh(Node[] targets, IncMesh mesh, bool mirrorHoriz = false, float axisHoriz = 0, bool mirrorVert = false, float axisVert = 0)
+    {
+        auto provider = new GenericProjectionAlphaProvider(targets);
+        scope(exit) provider.dispose();
+        return this.autoMesh(provider, mesh, mirrorHoriz, axisHoriz, mirrorVert, axisVert);
     }
     override void configure() {
         if (MAX_DISTANCE < 0)
@@ -307,6 +447,12 @@ public:
         }
         incEndCategory();
         igPopID();
+
+        igSeparator();
+        incText(_("Alpha Preview"));
+        igIndent();
+        alphaPreviewWidget(_alphaPreview, ImVec2(192, 192));
+        igUnindent();
     }
     override 
     string icon() {

--- a/source/nijigenerate/viewport/vertex/automesh/grid.d
+++ b/source/nijigenerate/viewport/vertex/automesh/grid.d
@@ -28,11 +28,11 @@ class GridAutoMeshProcessor : AutoMeshProcessor {
 public:
     override
     IncMesh autoMesh(Drawable target, IncMesh mesh, bool mirrorHoriz = false, float axisHoriz = 0, bool mirrorVert = false, float axisVert = 0) {
-        // 1) 最初の処理だけ分岐: AlphaInput の取得
+        // 1) Branch only for input acquisition
         auto ai = getAlphaInput(target);
         if (ai.w <= 0 || ai.h <= 0) return mesh;
 
-        // 2) 共通処理: マスクの二値化と外接矩形の算出
+        // 2) Common: binarize alpha and compute bounding box
         auto imbin = ai.img.sliced[0 .. $, 0 .. $, 3];
         foreach (y; 0 .. imbin.shape[0])
         foreach (x; 0 .. imbin.shape[1])
@@ -49,9 +49,9 @@ public:
                 if (xi > maxX) maxX = xi;
                 if (yi > maxY) maxY = yi;
             }
-        if (maxX < 0 || maxY < 0) return mesh; // マスク無し
+        if (maxX < 0 || maxY < 0) return mesh; // no mask found
 
-        // 3) 共通処理: グリッド軸作成（画像中心基準）
+        // 3) Common: build grid axes (relative to image center)
         mesh.clear();
         vec2 imgCenter = alphaImageCenter(ai);
 
@@ -70,7 +70,7 @@ public:
         meshData.regenerateGrid();
         mesh.copyFromMeshData(meshData);
 
-        // 4) 共通処理: 対象ローカル座標へマッピング
+        // 4) Common: map to target local coordinates
         mapImageCenteredMeshToTargetLocal(mesh, target, ai);
         return mesh;
     }

--- a/source/nijigenerate/viewport/vertex/automesh/package.d
+++ b/source/nijigenerate/viewport/vertex/automesh/package.d
@@ -5,3 +5,4 @@ public import nijigenerate.viewport.vertex.automesh.contours;
 public import nijigenerate.viewport.vertex.automesh.grid;
 public import nijigenerate.viewport.vertex.automesh.skeletonize;
 public import nijigenerate.viewport.vertex.automesh.optimum;
+public import nijigenerate.viewport.vertex.automesh.alpha_provider;

--- a/source/nijigenerate/viewport/vertex/automesh/skeletonize.d
+++ b/source/nijigenerate/viewport/vertex/automesh/skeletonize.d
@@ -9,8 +9,8 @@ import nijigenerate.core.math.skeletonize;
 import nijigenerate.core.math.path;
 import inmath;
 import mir.ndslice;
-import mir.ndslice.slice;    // NDslice 用の slice 操作
-import mir.ndslice.topology; // reshape() などのため
+import mir.ndslice.slice;    // NDslice slice operations
+import mir.ndslice.topology; // for reshape(), etc.
 import mir.math.stat: mean;
 import nijigenerate.core.cv;
 import std.algorithm;
@@ -23,17 +23,16 @@ import nijigenerate.viewport.vertex.automesh.alpha_provider;
 import nijigenerate.core.cv.image;
 import nijigenerate.viewport.vertex.automesh.common : getAlphaInput, mapImageCenteredMeshToTargetLocal;
 
-alias Point = vec2u; // vec2u は (uint x, uint y) を想定（必要に応じて調整）
+alias Point = vec2u; // vec2u is (uint x, uint y)
 
-/// SkeletonExtractor クラス
-/// - 入力画像は ubyte[] 形式で与えられ、幅・高さから各画素は img[y][x] = img2[y*width + x] でアクセス可能とする。
-/// - autoMesh() 内で、画像のバイナリ化→Zhang-Suen 細線化→連続パス抽出→RDP による制御点抽出を行い、
-///   さらに制御点群を「Y 座標が最も少ない点を原点 (0,0) にする」よう平行移動します。
+/// SkeletonExtractor
+/// - Input: image alpha; processes as ubyte grid accessible via img[y][x].
+/// - In autoMesh(): binarize → Zhang-Suen skeletonization → path extraction → RDP-like simplification.
 class SkeletonExtractor : AutoMeshProcessor {
 private:
     float maskThreshold = 15;
     int targetPointCount = 10;
-    Point[] controlPoints; // RDP により得られた制御点群（後で平行移動済み）
+    Point[] controlPoints; // Control points after simplification
     // Unified alpha preview state
     private AlphaPreviewState _alphaPreview;
 
@@ -42,22 +41,22 @@ public:
                               bool mirrorHoriz = false, float axisHoriz = 0,
                               bool mirrorVert = false, float axisVert = 0)
     {
-        // 1) 最初の処理のみ分岐: AlphaInput の取得
+        // 1) Branch only for AlphaInput acquisition
         auto ai = getAlphaInput(target);
         if (ai.w <= 0 || ai.h <= 0 || ai.img is null) return mesh;
 
-        // 2) 共通処理: 二値化
+        // 2) Common: binarization
         auto imbin = ai.img.sliced[0 .. $, 0 .. $, 3].dup;
         foreach (y; 0 .. imbin.shape[0])
         foreach (x; 0 .. imbin.shape[1])
             imbin[y, x] = imbin[y, x] < cast(ubyte)maskThreshold ? 0 : 255;
 
-        // 3) 共通処理: 細線化 → パス抽出 → 単純化
+        // 3) Common: skeletonize → extract path → simplify
         skeletonizeImage(imbin);
         auto path = extractPath(imbin, ai.w, ai.h);
         controlPoints = simplifyByTargetCount(path, targetPointCount);
 
-        // 4) 共通処理: 画像中心基準で頂点生成
+        // 4) Common: create vertices relative to image center
         mesh.clear();
         vec2 imgCenter = vec2(ai.w / 2, ai.h / 2);
         foreach (Point pt; controlPoints) {
@@ -65,7 +64,7 @@ public:
             mesh.vertices ~= new MeshVertex(position - imgCenter);
         }
 
-        // 5) 共通処理: 対象ローカルへマッピング
+        // 5) Common: map to target local
         mapImageCenteredMeshToTargetLocal(mesh, target, ai);
         return mesh.autoTriangulate();
     }
@@ -78,7 +77,7 @@ public:
         igUnindent();
     }
 
-    /// 抽出された制御点の取得
+    /// Get extracted control points
     Point[] getControlPoints() {
         return controlPoints;
     }
@@ -86,16 +85,16 @@ public:
 private:
 
     /////////////////////////////////////////////////////////////
-    // 4. Visvalingam–Whyatt 法に基づく、指定したポイント数に単純化するアルゴリズム
+    // Simplify to target count (Visvalingam–Whyatt-like)
     Point[] simplifyByTargetCount(Point[] pts, int targetCount) {
-        // pts の数が既に目標以下ならそのまま返す
+        // If already <= target, return copy
         if (pts.length <= targetCount)
             return pts.dup;
 
-        // 内部点（先頭と末尾は保持）を順次削除して目標数にする
+        // Iteratively remove interior points (keep endpoints)
         auto simplified = pts.dup;
 
-        // ヘルパー：3点 (a, b, c) から三角形の面積を計算
+        // Helper: triangle area from 3 points (a, b, c)
         auto triangleArea = (Point a, Point b, Point c) {
             double ax = cast(double)a.x, ay = cast(double)a.y;
             double bx = cast(double)b.x, by = cast(double)b.y;
@@ -107,7 +106,7 @@ private:
         while (simplified.length > targetCount) {
             int removeIndex = 1;
             double minArea = triangleArea(simplified[0], simplified[1], simplified[2]);
-            // 内部点（先頭と末尾は除く）について、三角形の面積が最小となる点を探索
+            // Find interior point with smallest triangle area
             for (int i = 2; i < simplified.length - 1; i++) {
                 double area = triangleArea(simplified[i - 1], simplified[i], simplified[i + 1]);
                 if (area < minArea) {
@@ -115,7 +114,7 @@ private:
                     removeIndex = i;
                 }
             }
-            // 最小の内部点を削除
+            // Remove the smallest-area interior point
             simplified = simplified[0 .. removeIndex] ~ simplified[removeIndex + 1 .. $];
         }
         return simplified;


### PR DESCRIPTION
Functional Summary

- Enable AutoMesh on non-Part targets (MeshGroup, Mask, Shape, arbitrary Node[]).
- Use CPU-readable alpha as the single source for contour/skeleton/optimum processing.
- Produce consistent results between Part and non-Part by mapping image-centered vertices into target-local space.

Implementation Overview
- Alpha input abstraction: introduce IAlphaProvider with concrete providers
 - PartAlphaProvider, MeshGroupAlphaProvider, GenericProjectionAlphaProvider.
- Common helpers: AlphaInput utilities to acquire alpha (from Drawable or Provider) and map image-centered vertices to target-local coordinates.
- Processor unification: contours/grid/optimum/skeletonize share the same flow
  - Step 1 (branch): acquire AlphaInput
  - Step 2+: binarize alpha → process (findContours/skeletonize/optimize) → create vertices around image center → map to target local.