### PR TITLE
Fixed macos x86_64 OpenSSL linking

### DIFF
--- a/.github/workflows/build-and-candidate.yml
+++ b/.github/workflows/build-and-candidate.yml
@@ -217,6 +217,14 @@ jobs:
         # Remove conflicting brew items
         brew remove --ignore-dependencies libpng brotli harfbuzz
 
+    - name: "Fetch openssl x86_64 bottle via brew"
+      continue-on-error: true
+      run: |
+        # sonoma = macos-14
+        TAR=$(brew fetch --bottle-tag=x86_64_sonoma openssl@3 | grep '/.\+openssl@3.\+sonoma.\+tar\.gz' -o)
+        tar -xzf "$TAR"
+        ln -s ./openssl@3/3.* ./openssl_3
+
     - name: "Remove final conflicting files"
       continue-on-error: true
       run: |

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -218,6 +218,20 @@ jobs:
         # Remove conflicting brew items
         brew remove --ignore-dependencies libpng brotli harfbuzz
 
+    - name: "Download openssl x86_64"
+      continue-on-error: true
+      run: |
+        # https://github.com/Homebrew/homebrew-core/blob/main/Formula/o/openssl@3.rb
+        # sonoma = macos-14
+        URL="https://ghcr.io/v2/homebrew/core/openssl/3/blobs/sha256:dcbc84c30251575424915590a347d12f89088e055a76da319422f887d9e71faf"
+        REPO="homebrew/core/openssl/3"
+        TOKEN_JSON=$(curl -s "https://ghcr.io/token?service=ghcr.io&scope=repository:${REPO}:pull")
+        token=$(echo "$TOKEN_JSON" | jq -r .token)
+        curl -H "Authorization: Bearer $token" -L -o openssl3.tar.gz "$URL"
+        tar -xf openssl3.tar.gz
+        ln -s ./openssl@3/3.* ./openssl_3
+
+
     - name: "Remove final conflicting files"
       continue-on-error: true
       run: |

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -218,19 +218,13 @@ jobs:
         # Remove conflicting brew items
         brew remove --ignore-dependencies libpng brotli harfbuzz
 
-    - name: "Download openssl x86_64"
+    - name: "Fetch openssl x86_64 bottle via brew"
       continue-on-error: true
       run: |
-        # https://github.com/Homebrew/homebrew-core/blob/main/Formula/o/openssl@3.rb
         # sonoma = macos-14
-        URL="https://ghcr.io/v2/homebrew/core/openssl/3/blobs/sha256:dcbc84c30251575424915590a347d12f89088e055a76da319422f887d9e71faf"
-        REPO="homebrew/core/openssl/3"
-        TOKEN_JSON=$(curl -s "https://ghcr.io/token?service=ghcr.io&scope=repository:${REPO}:pull")
-        token=$(echo "$TOKEN_JSON" | jq -r .token)
-        curl -H "Authorization: Bearer $token" -L -o openssl3.tar.gz "$URL"
-        tar -xf openssl3.tar.gz
+        TAR=$(brew fetch --bottle-tag=x86_64_sonoma openssl@3 | grep '/.\+openssl@3.\+sonoma.\+tar\.gz' -o)
+        tar -xzf "$TAR"
         ln -s ./openssl@3/3.* ./openssl_3
-
 
     - name: "Remove final conflicting files"
       continue-on-error: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -217,17 +217,12 @@ jobs:
         # Remove conflicting brew items
         brew remove --ignore-dependencies libpng brotli harfbuzz
 
-    - name: "Download openssl x86_64"
+    - name: "Fetch openssl x86_64 bottle via brew"
       continue-on-error: true
       run: |
-        # https://github.com/Homebrew/homebrew-core/blob/main/Formula/o/openssl@3.rb
         # sonoma = macos-14
-        URL="https://ghcr.io/v2/homebrew/core/openssl/3/blobs/sha256:dcbc84c30251575424915590a347d12f89088e055a76da319422f887d9e71faf"
-        REPO="homebrew/core/openssl/3"
-        TOKEN_JSON=$(curl -s "https://ghcr.io/token?service=ghcr.io&scope=repository:${REPO}:pull")
-        token=$(echo "$TOKEN_JSON" | jq -r .token)
-        curl -H "Authorization: Bearer $token" -L -o openssl3.tar.gz "$URL"
-        tar -xf openssl3.tar.gz
+        TAR=$(brew fetch --bottle-tag=x86_64_sonoma openssl@3 | grep '/.\+openssl@3.\+sonoma.\+tar\.gz' -o)
+        tar -xzf "$TAR"
         ln -s ./openssl@3/3.* ./openssl_3
 
     - name: "Remove final conflicting files"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -217,6 +217,19 @@ jobs:
         # Remove conflicting brew items
         brew remove --ignore-dependencies libpng brotli harfbuzz
 
+    - name: "Download openssl x86_64"
+      continue-on-error: true
+      run: |
+        # https://github.com/Homebrew/homebrew-core/blob/main/Formula/o/openssl@3.rb
+        # sonoma = macos-14
+        URL="https://ghcr.io/v2/homebrew/core/openssl/3/blobs/sha256:dcbc84c30251575424915590a347d12f89088e055a76da319422f887d9e71faf"
+        REPO="homebrew/core/openssl/3"
+        TOKEN_JSON=$(curl -s "https://ghcr.io/token?service=ghcr.io&scope=repository:${REPO}:pull")
+        token=$(echo "$TOKEN_JSON" | jq -r .token)
+        curl -H "Authorization: Bearer $token" -L -o openssl3.tar.gz "$URL"
+        tar -xf openssl3.tar.gz
+        ln -s ./openssl@3/3.* ./openssl_3
+
     - name: "Remove final conflicting files"
       continue-on-error: true
       run: |

--- a/BUILD.md
+++ b/BUILD.md
@@ -48,6 +48,18 @@ sudo dnf -y install \
     dbus-devel
 ```
 
+### macos
+```bash
+brew update
+brew install create-dmg gettext ldc
+
+# for mcp server
+brew install openssl@3 
+```
+For other dependencies, refer to Linux and use brew commands instead.
+
+For `x86_64` builds you need to install the `x86_64` version of brew, then install openssl@3
+
 ## Build nijilive Project
 First, we need to clone the four projects under nijigenerate and add them to `dub add-local`.
 ```bash
@@ -84,7 +96,6 @@ dub build --config=meta
 dub build --compiler=ldc2 --build=release --config=linux-full
 ./out/nijigenerate
 ```
-
 build nijiexpose
 ```
 cd nijiexpose
@@ -93,3 +104,13 @@ dub build --compiler=ldc2 --build=release --config=linux-full
 ./out/nijiexpose
 ```
 
+## Packing up a dmg file
+```
+./gentl.sh
+# macos arm64
+dub build --compiler=ldc2 --build=release --config=osx-full --arch=arm64-apple-macos
+# macos x86_64
+# dub build --compiler=ldc2 --build=release --config=osx-full --arch=x86_64-apple-macos
+./build-aux/osx/osxbundle.sh
+./build-aux/osx/gendmg.sh
+```

--- a/dub.sdl
+++ b/dub.sdl
@@ -14,13 +14,6 @@ dependency "nijilive" version="~>0.0.1"
 dependency "mcp" version="~>1.0.1"
 dependency "vibe-d:http" version="~>0.10.0"
 
-// Disable tls until vibe upstream supports openssl 3.x
-// https://github.com/vibe-d/vibe.d/issues/2648
-// homebrew openssl 1.1 is deprecated, may not work on macOS arm64
-// https://formulae.brew.sh/formula/openssl@1.1
-dependency "vibe-stream:tls" version="~>1.0"
-subConfiguration "vibe-stream:tls" "notls"
-
 targetPath "out/"
 workingDirectory "out/"
 dflags "-mscrtlib=msvcrt" platform="windows-ldc"
@@ -53,6 +46,11 @@ configuration "osx-full" {
 	subConfiguration "i2d-imgui" "dynamic_dynamicCRT"
 	dflags "-force-dwarf-frame-section=false"
 	lflags "-rpath" "@executable_path/../Frameworks" "-rpath" "@executable_path/."
+
+  // ln -s /usr/local/Cellar/openssl@3/3.* ./openssl_3
+  lflags "-L./openssl_3/lib" platform="osx-x86_64"
+  lflags "-L/opt/homebrew/opt/openssl@3/lib" platform="osx-arm64"
+  lflags "-L/opt/homebrew/opt/openssl@3/lib" platform="osx-aarch64"
 }
 
 // Windows build
@@ -82,6 +80,11 @@ configuration "osx-nightly" {
 	dflags "-force-dwarf-frame-section=false"
 	lflags "-rpath" "@executable_path/../Frameworks" "-rpath" "@executable_path/."
 	versions "InNightly"
+
+  // ln -s /usr/local/Cellar/openssl@3/3.* ./openssl_3
+  lflags "-L./openssl_3/lib" platform="osx-x86_64"
+  lflags "-L/opt/homebrew/opt/openssl@3/lib" platform="osx-arm64"
+  lflags "-L/opt/homebrew/opt/openssl@3/lib" platform="osx-aarch64"
 }
 
 // Windows nightly build


### PR DESCRIPTION
Resolve the missing x86_64 library issue by downloading from ghcr.io/v2/homebrew/core/openssl/3

refer to  https://github.com/Homebrew/homebrew-core/blob/main/Formula/o/openssl@3.rb

Nightly build dmg successfully
https://github.com/r888800009/nijigenerate/tree/fix/openssl_build
https://github.com/r888800009/nijigenerate/actions/runs/17530865249/job/49787639116