### PR TITLE
[feature/mcp-auth] Add HTTPS support with self-signed certificate generation in HttpTransport

### DIFF
--- a/source/nijigenerate/api/mcp/http_transport.d
+++ b/source/nijigenerate/api/mcp/http_transport.d
@@ -151,7 +151,13 @@ private:
         }
         return false;
     }
-    string selfBase() { return "http://" ~ host ~ ":" ~ to!string(port); }
+    string selfBase() {
+        bool enabledSSL = incSettingsGet!bool("MCP.https", true);
+        if (enabledSSL) {
+            return "https://" ~ host ~ ":" ~ to!string(port);
+        }
+        return "http://" ~ host ~ ":" ~ to!string(port); 
+    }
     string protectedResourceMetadataUrl() { return selfBase() ~ "/.well-known/oauth-protected-resource/mcp"; }
 
     // ===== Utils for tokens/PKCE =====

--- a/source/nijigenerate/api/mcp/http_transport.d
+++ b/source/nijigenerate/api/mcp/http_transport.d
@@ -444,7 +444,7 @@ public:
             if (!exists(outDir)) mkdirRecurse(outDir);
             auto certPath = buildPath(outDir, "server.crt");
             auto keyPath  = buildPath(outDir, "server.key");
-            ngCreateSelfSignedCertificate(certPath.toStringz, keyPath.toStringz);
+            ngCreateSelfSignedCertificate(certPath, keyPath);
             settings.tlsContext = createTLSContext(TLSContextKind.server);
             settings.tlsContext.useCertificateChainFile(certPath);
             settings.tlsContext.usePrivateKeyFile(keyPath);

--- a/source/nijigenerate/api/mcp/http_transport.d
+++ b/source/nijigenerate/api/mcp/http_transport.d
@@ -35,12 +35,14 @@ import vibe.http.client;
 import vibe.core.core : runApplication, exitEventLoop, yield, runTask, setTimer, sleep;
 import vibe.core.stream : OutputStream, InputStream;
 import vibe.stream.operations : readAllUTF8;
+import vibe.stream.tls;
 import std.uri : decodeComponent;
 
 import mcp.transport.stdio;
 import mcp.server;
 import nijigenerate.api.mcp.task;
 import nijigenerate.api.mcp.auth;
+import nijigenerate.api.mcp.https : ngCreateSelfSignedCertificate;
 
 // ======================= HTTP Transport =======================
 class HttpTransport : Transport {
@@ -427,8 +429,19 @@ public:
         router.get("/auth/authorize", &handleAuthorize);
         router.post("/auth/token",    &handleToken);
 
-        // Start server
+        // settings
         auto settings = new HTTPServerSettings;
+
+        // self-signed certificate
+        auto enabledSSL = true;
+        if (enabledSSL) {
+            ngCreateSelfSignedCertificate();
+            settings.tlsContext = createTLSContext(TLSContextKind.server);
+            settings.tlsContext.useCertificateChainFile("server.crt");
+            settings.tlsContext.usePrivateKeyFile("server.key");
+        }
+
+        // Start server
         settings.port = port;
         settings.bindAddresses = [host];
         listener = listenHTTP(settings, router);

--- a/source/nijigenerate/api/mcp/http_transport.d
+++ b/source/nijigenerate/api/mcp/http_transport.d
@@ -43,6 +43,7 @@ import mcp.server;
 import nijigenerate.api.mcp.task;
 import nijigenerate.api.mcp.auth;
 import nijigenerate.api.mcp.https : ngCreateSelfSignedCertificate;
+import nijigenerate.core.settings; // incSettingsGet
 
 // ======================= HTTP Transport =======================
 class HttpTransport : Transport {
@@ -432,13 +433,21 @@ public:
         // settings
         auto settings = new HTTPServerSettings;
 
-        // self-signed certificate
-        auto enabledSSL = true;
+        // HTTPS (self-signed) optional
+        bool enabledSSL = incSettingsGet!bool("MCP.https", true);
         if (enabledSSL) {
-            ngCreateSelfSignedCertificate();
+            import std.path : buildPath;
+            import std.file : mkdirRecurse, exists;
+            import std.string : toStringz;
+            import nijigenerate.core.path : incGetAppConfigPath;
+            auto outDir = buildPath(incGetAppConfigPath(), "mcp");
+            if (!exists(outDir)) mkdirRecurse(outDir);
+            auto certPath = buildPath(outDir, "server.crt");
+            auto keyPath  = buildPath(outDir, "server.key");
+            ngCreateSelfSignedCertificate(certPath.toStringz, keyPath.toStringz);
             settings.tlsContext = createTLSContext(TLSContextKind.server);
-            settings.tlsContext.useCertificateChainFile("server.crt");
-            settings.tlsContext.usePrivateKeyFile("server.key");
+            settings.tlsContext.useCertificateChainFile(certPath);
+            settings.tlsContext.usePrivateKeyFile(keyPath);
         }
 
         // Start server

--- a/source/nijigenerate/api/mcp/https.d
+++ b/source/nijigenerate/api/mcp/https.d
@@ -21,6 +21,7 @@ extern(C) void ngCreateSelfSignedCertificate(const(char)* certPath, const(char)*
     SSL_library_init();
     OpenSSL_add_all_algorithms();
     SSL_load_error_strings();
+    RAND_poll();
 
     // Only generate artifacts; do not configure SSL_CTX here
 

--- a/source/nijigenerate/api/mcp/https.d
+++ b/source/nijigenerate/api/mcp/https.d
@@ -14,7 +14,7 @@ import deimos.openssl.x509v3;
 
 public:
 
-extern(C) SSL_CTX* ngCreateSelfSignedCertificate() {
+extern(C) void ngCreateSelfSignedCertificate(const(char)* certPath, const(char)* keyPath) {
     SSL_CTX* ctx;
     EVP_PKEY* pkey = null;
     X509* x509 = null;
@@ -59,17 +59,17 @@ extern(C) SSL_CTX* ngCreateSelfSignedCertificate() {
     X509_sign(x509, pkey, EVP_sha256());
 
     // Write certificate and private key to files (vibe-d requires file)
-    auto certFile = fopen("server.crt", "w");
+    auto certFile = fopen(certPath, "w");
     if (certFile is null) {
-        writefln("Failed to open server.crt\n");
+        writefln("Failed to open cert file\n");
         exit(EXIT_FAILURE);
     }
     PEM_write_X509(certFile, x509);
     fclose(certFile);
 
-    auto keyFile = fopen("server.key", "w");
+    auto keyFile = fopen(keyPath, "w");
     if (keyFile is null) {
-        writefln("Failed to open server.key\n");
+        writefln("Failed to open key file\n");
         exit(EXIT_FAILURE);
     }
     PEM_write_PrivateKey(keyFile, pkey, null, null, 0, null, null);
@@ -88,5 +88,9 @@ extern(C) SSL_CTX* ngCreateSelfSignedCertificate() {
     EVP_PKEY_free(pkey);
     X509_free(x509);
 
-    return ctx;
+    // Do not return ctx as we only generate and write files now
+    EVP_PKEY_free(pkey);
+    X509_free(x509);
+    SSL_CTX_free(ctx);
+    return;
 }

--- a/source/nijigenerate/api/mcp/https.d
+++ b/source/nijigenerate/api/mcp/https.d
@@ -1,0 +1,92 @@
+module nijigenerate.api.mcp.https;
+
+import core.stdc.stdio : FILE, fopen, fclose, stderr;
+import core.stdc.stdlib : exit, EXIT_FAILURE;
+import std.stdio;
+
+import deimos.openssl.bio;
+import deimos.openssl.err;
+import deimos.openssl.opensslv;
+import deimos.openssl.rand;
+import deimos.openssl.ssl;
+import deimos.openssl.stack;
+import deimos.openssl.x509v3;
+
+public:
+
+extern(C) SSL_CTX* ngCreateSelfSignedCertificate() {
+    SSL_CTX* ctx;
+    EVP_PKEY* pkey = null;
+    X509* x509 = null;
+
+    SSL_library_init();
+    OpenSSL_add_all_algorithms();
+    SSL_load_error_strings();
+
+    ctx = SSL_CTX_new(TLS_server_method());
+    if (ctx is null) {
+        ERR_print_errors_fp(stderr);
+        exit(EXIT_FAILURE);
+    }
+
+    // Set TLS 1.2+ only and disable insecure options
+    SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
+    SSL_CTX_set_max_proto_version(ctx, TLS1_3_VERSION);
+    SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION);
+
+    // Generate ECC P-256 private key
+    pkey = EVP_PKEY_new();
+    auto ecKey = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
+    if (EC_KEY_generate_key(ecKey) != 1) {
+        writefln("Failed to generate ECC key\n");
+        exit(EXIT_FAILURE);
+    }
+    EVP_PKEY_assign_EC_KEY(pkey, ecKey);
+
+    // Generate X509 self-signed certificate
+    x509 = X509_new();
+    ASN1_INTEGER_set(X509_get_serialNumber(x509), 1);
+    X509_gmtime_adj(X509_get_notBefore(x509), 0);
+    X509_gmtime_adj(X509_get_notAfter(x509), 31536000L); // 1 year validity
+    X509_set_pubkey(x509, pkey);
+
+    auto name = X509_get_subject_name(x509);
+    X509_NAME_add_entry_by_txt(name, "C",  MBSTRING_ASC, cast(ubyte*)"US", -1, -1, 0);
+    X509_NAME_add_entry_by_txt(name, "O",  MBSTRING_ASC, cast(ubyte*)"TestOrg", -1, -1, 0);
+    X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, cast(ubyte*)"localhost", -1, -1, 0);
+    X509_set_issuer_name(x509, name);
+
+    X509_sign(x509, pkey, EVP_sha256());
+
+    // Write certificate and private key to files (vibe-d requires file)
+    auto certFile = fopen("server.crt", "w");
+    if (certFile is null) {
+        writefln("Failed to open server.crt\n");
+        exit(EXIT_FAILURE);
+    }
+    PEM_write_X509(certFile, x509);
+    fclose(certFile);
+
+    auto keyFile = fopen("server.key", "w");
+    if (keyFile is null) {
+        writefln("Failed to open server.key\n");
+        exit(EXIT_FAILURE);
+    }
+    PEM_write_PrivateKey(keyFile, pkey, null, null, 0, null, null);
+    fclose(keyFile);
+
+    // Set certificate and key to SSL_CTX
+    if (SSL_CTX_use_certificate(ctx, x509) <= 0) {
+        ERR_print_errors_fp(stderr);
+        exit(EXIT_FAILURE);
+    }
+    if (SSL_CTX_use_PrivateKey(ctx, pkey) <= 0) {
+        ERR_print_errors_fp(stderr);
+        exit(EXIT_FAILURE);
+    }
+
+    EVP_PKEY_free(pkey);
+    X509_free(x509);
+
+    return ctx;
+}

--- a/source/nijigenerate/windows/settings.d
+++ b/source/nijigenerate/windows/settings.d
@@ -312,6 +312,10 @@ protected:
                                 if (ngCheckbox(__("Enabled authorization."), &authEnabled)) {
                                     incSettingsSet("MCP.authEnabled", authEnabled);
                                 }
+                                bool httpsEnabled = incSettingsGet!bool("MCP.https", true);
+                                if (ngCheckbox(__("Enable HTTPS (self-signed)"), &httpsEnabled)) {
+                                    incSettingsSet("MCP.https", httpsEnabled);
+                                }
                             } else {
                                 incTooltip(_("Server disabled. Click Done to apply."));
                             }


### PR DESCRIPTION
## Description:
This PR introduces HTTPS support for MCP HttpTransport by generating a self-signed certificate programmatically.

## Notes:

The HTTPS server uses ECC P-256 for key generation.

The certificate and key are written to server.crt and server.key files for use with vibe.d.

This enhancement ensures that MCP authentication is not effectively bypassed due to unencrypted HTTP transport and provides a safer local testing environment.