### PR TITLE
feat(core): track saved state and show modified dot

### DIFF
--- a/source/nijigenerate/io/save.d
+++ b/source/nijigenerate/io/save.d
@@ -20,10 +20,8 @@ import i18n;
     check project has changes
 */
 bool incIsProjectModified() {
-    // TODO: we need more detailed check, maybe history action stack or tracking all changes
-    // currently just assume user history action stack should record all changes
-    // if not record, it is action stack bug
-    return !incIsActionStackEmpty();
+    // Consider project modified if action pointer differs from last saved index
+    return incActionIsModified();
 }
 
 bool incFileOpen() {

--- a/source/nijigenerate/project.d
+++ b/source/nijigenerate/project.d
@@ -363,6 +363,11 @@ void incSaveProject(string path, string autosaveStamp = "") {
         inWriteINPPuppet(incActivePuppet(), swapPath);
         rename(swapPath, finalPath);
 
+        // Update modified state only for manual saves
+        if (!isAutosave) {
+            incActionMarkSaved();
+        }
+
         if (!isAutosave) incReleaseLockfile();
         incActivePuppet().resetDrivers();
 


### PR DESCRIPTION
 Add savedIndex to action stack and expose incActionMarkSaved()/incActionIsModified()
- Update incIsProjectModified() to compare against last saved index
- Mark saved on manual saves; autosaves don’t change saved state
- Update window title to append ‘●’ when project has unsaved changes
- Refresh title on state changes each frame