### PR TITLE
feat(commands): add DefineMeshCommand and SetDeformBindingComnand

### DIFF
--- a/source/nijigenerate/api/mcp/server.d
+++ b/source/nijigenerate/api/mcp/server.d
@@ -211,6 +211,9 @@ private void _ngMcpStart(string host, ushort port) {
                                 } else static if (is(TParam == float[3])) {
                                     inputSchema = inputSchema.addProperty(fname, SchemaBuilder.array(SchemaBuilder.number()).setDescription((fdesc.length?fdesc~"; ":"")~"float[3] [x,y,z]"));
                                     paramLog ~= fname ~ ":float[3]";
+                                } else static if (is(TParam == ushort[])) {
+                                    inputSchema = inputSchema.addProperty(fname, SchemaBuilder.array(SchemaBuilder.integer()).setDescription((fdesc.length?fdesc~"; ":"")~"ushort[]"));
+                                    paramLog ~= fname ~ ":float[]";
                                 } else static if (is(TParam == uint[2])) {
                                     inputSchema = inputSchema.addProperty(fname, SchemaBuilder.array(SchemaBuilder.integer()).setDescription((fdesc.length?fdesc~"; ":"")~"uint[2] [x,y]"));
                                     paramLog ~= fname ~ ":uint[2]";
@@ -377,6 +380,17 @@ private void _ngMcpStart(string host, ushort port) {
                                                             float y = cast(float)(a[1].type==JSONType.float_ ? a[1].floating : cast(double)a[1].integer);
                                                             float z = cast(float)(a[2].type==JSONType.float_ ? a[2].floating : cast(double)a[2].integer);
                                                             mixin("inst."~fname~" = [x,y,z];");
+                                                        }
+                                                    } else static if (is(TParam == ushort[])) {
+                                                        if (val.type == JSONType.array) {
+                                                            ushort[] outv;
+                                                            foreach (e; val.array) {
+                                                                if (e.type == JSONType.float_)
+                                                                    outv ~= cast(ushort)e.floating;
+                                                                else if (e.type == JSONType.integer)
+                                                                    outv ~= cast(ushort)cast(double)e.integer;
+                                                            }
+                                                            mixin("inst."~fname~" = outv;");
                                                         }
                                                     } else static if (is(TParam == uint[2])) {
                                                         if (val.type == JSONType.array && val.array.length >= 2) {

--- a/source/nijigenerate/commands/model/set_deform_binding.d
+++ b/source/nijigenerate/commands/model/set_deform_binding.d
@@ -1,0 +1,178 @@
+module nijigenerate.commands.model.set_deform_binding;
+
+import nijigenerate.commands.base;
+import nijigenerate.actions.parameter; // ParameterChangeBindingsValueAction
+import nijigenerate.actions;           // GroupAction, ParameterBindingAddAction
+import nijigenerate.core.actionstack : incActionPush;
+import nijigenerate.project : incSelectedNodes, incArmedParameter;
+import nijigenerate.viewport.model.deform : incViewportNodeDeformNotifyParamValueChanged;
+import nijilive; // Parameter, Node, Drawable, Deformable
+import nijilive.math : vec2, vec2u;
+import std.algorithm : map, filter;
+import std.array : array;
+import std.conv : to;
+import std.exception : enforce;
+import i18n;
+
+/**
+    Set Deformation binding at current keypoint using provided offsets.
+
+    - values: flattened [dx0,dy0, dx1,dy1, ...]
+    Applies to the first armed Parameter (or ctx.parameters[0] if provided),
+    and to selected nodes that already have a deform binding.
+*/
+class SetDeformBindingCommand : ExCommand!(
+    TW!(string,  "bindingName", "Binding name (e.g., 'deform' or value name)"),
+    TW!(float[], "values",      "Flattened values: deform=[dx,dy]*, other=[v]")
+) {
+    this(string bname, float[] vals) {
+        super(_("Set Binding"), _("Set binding value(s) at current keypoint."), bname, vals);
+    }
+
+    override bool runnable(Context ctx) {
+        // Need a parameter context and at least one deformable node
+        bool hasParam = (ctx.hasArmedParameters && ctx.armedParameters.length > 0) || (ctx.hasParameters && ctx.parameters.length > 0) || (incArmedParameter() !is null);
+        if (!hasParam) return false;
+        Node[] ns = ctx.hasNodes ? ctx.nodes : incSelectedNodes();
+        foreach (n; ns) if (cast(Drawable)n || cast(Deformable)n) return true;
+        return false;
+    }
+
+    // Not available via shortcut (requires external data)
+    override bool shortcutRunnable() { return false; }
+
+    override void run(Context ctx) {
+        if (!runnable(ctx)) return;
+
+        // No-op if values not provided
+        if (values is null || values.length == 0) return;
+
+        // Resolve parameter to operate on
+        Parameter[] params;
+        if (ctx.hasArmedParameters && ctx.armedParameters.length > 0) params = ctx.armedParameters;
+        else if (ctx.hasParameters && ctx.parameters.length > 0) params = ctx.parameters;
+        else if (auto p = incArmedParameter()) params = [p];
+        if (params.length == 0) return;
+
+        // Resolve targets
+        Node[] ns = ctx.hasNodes ? ctx.nodes : incSelectedNodes();
+        if (ns.length == 0) return;
+
+        // For each parameter, set binding at target keypoint
+        foreach (param; params) {
+            // Determine keypoint
+            vec2u kp = ctx.hasKeyPoint ? ctx.keyPoint : param.findClosestKeypoint();
+
+            // Prepare sets and track new bindings to add undo/redo entries
+            DeformationParameterBinding[] deformBindings;
+            ValueParameterBinding[]       valueBindings;
+            ParameterBinding[]            newlyAdded;
+
+            // Pre-parse deform offsets if applicable
+            vec2[] offsets;
+            bool hasOffsets = (values.length >= 2) && (values.length % 2 == 0);
+            if (hasOffsets) {
+                offsets.length = values.length / 2;
+                foreach (i; 0 .. offsets.length) offsets[i] = vec2(values[i*2], values[i*2 + 1]);
+            }
+
+            // Collect or create bindings for each selected node, then dispatch by concrete type
+            bool deformMismatch = false;
+            foreach (n; ns) {
+                // Try resolve existing binding first
+                auto existing = param.getBinding(n, bindingName);
+                bool wasNull = (existing is null);
+                ParameterBinding b = existing;
+
+                // Branch by concrete binding type, not by name
+                if (auto db = cast(DeformationParameterBinding)b) {
+                    // Only valid on deformable/drawable nodes and with even-length offsets
+                    if (!hasOffsets) { deformMismatch = true; continue; }
+                    size_t expected = 0;
+                    if (auto d = cast(Drawable)n) expected = d.getMesh().vertices.length;
+                    else if (auto df = cast(Deformable)n) expected = df.vertices.length;
+                    else { deformMismatch = true; continue; }
+                    if (expected != offsets.length) { deformMismatch = true; continue; }
+                    deformBindings ~= db;
+                    // existing deform binding case; wasNull is false here
+                } else if (auto vb = cast(ValueParameterBinding)b) {
+                    // Expect single scalar value
+                    if (values.length != 1) continue;
+                    valueBindings ~= vb;
+                    // existing value binding case
+                } else {
+                    // No existing binding; decide if we should create one
+                    if (hasOffsets) {
+                        // Targeting a deform-style update; only create for deformable/drawable with matching counts
+                        size_t expected = 0;
+                        if (auto d = cast(Drawable)n) expected = d.getMesh().vertices.length;
+                        else if (auto df = cast(Deformable)n) expected = df.vertices.length;
+                        else { deformMismatch = true; continue; }
+                        if (expected != offsets.length) { deformMismatch = true; continue; }
+
+                        // Create binding and verify type
+                        b = param.getOrAddBinding(n, bindingName);
+                        if (auto ndb = cast(DeformationParameterBinding)b) {
+                            deformBindings ~= ndb;
+                            newlyAdded ~= ndb;
+                        } else {
+                            // created wrong type; treat as mismatch
+                            deformMismatch = true;
+                            continue;
+                        }
+                    } else if (values.length == 1) {
+                        // Value-style; only create if node supports the parameter
+                        auto node = cast(Node)n;
+                        if (!node || !node.hasParam(bindingName)) continue;
+                        b = param.getOrAddBinding(n, bindingName);
+                        if (auto nvb = cast(ValueParameterBinding)b) {
+                            valueBindings ~= nvb;
+                            newlyAdded ~= nvb;
+                        }
+                    } else {
+                        // Neither deform nor valid value input
+                        continue;
+                    }
+                }
+            }
+
+            // If any deform target mismatches, do nothing for this parameter
+            if (deformMismatch) continue;
+
+            // Build grouped action with optional add-binding entries
+            auto group = new GroupAction();
+            foreach (nb; newlyAdded) {
+                group.addAction(new ParameterBindingAddAction(param, nb));
+            }
+            if (deformBindings.length > 0) {
+                auto action = new ParameterChangeBindingsValueAction(_("Set Deform Binding"), param, cast(ParameterBinding[])deformBindings, cast(int)kp.x, cast(int)kp.y);
+                foreach (b; deformBindings) b.update(kp, offsets);
+                action.updateNewState();
+                group.addAction(action);
+            }
+            if (valueBindings.length > 0) {
+                auto action = new ParameterChangeBindingsValueAction(_("Set Binding"), param, cast(ParameterBinding[])valueBindings, cast(int)kp.x, cast(int)kp.y);
+                float v = values[0];
+                foreach (b; valueBindings) b.setValue(kp, v);
+                action.updateNewState();
+                group.addAction(action);
+            }
+            if (!group.empty()) incActionPush(group);
+        }
+
+        // Refresh deformation viewport/editor state
+        incViewportNodeDeformNotifyParamValueChanged();
+    }
+}
+
+enum ModelCommand {
+    SetDeformBinding,
+}
+
+Command[ModelCommand] commands;
+
+void ngInitCommands(T)() if (is(T == ModelCommand))
+{
+    // Register with benign defaults; actual args supplied at call-time
+    mixin(registerCommand!(ModelCommand.SetDeformBinding, "deform", null));
+}

--- a/source/nijigenerate/commands/package.d
+++ b/source/nijigenerate/commands/package.d
@@ -19,6 +19,8 @@ public import nijigenerate.commands.view.panel;
 public import nijigenerate.commands.inspector.apply_node;
 public import nijigenerate.commands.automesh.dynamic;
 public import nijigenerate.commands.automesh.config;
+public import nijigenerate.commands.vertex.define_mesh;
+public import nijigenerate.commands.model.set_deform_binding;
 
 import std.meta : AliasSeq;
 import std.traits : BaseClassesTuple, isInstanceOf, TemplateArgsOf;
@@ -48,6 +50,8 @@ alias AllCommandMaps = AliasSeq!(
     nijigenerate.commands.automesh.dynamic.autoMeshApplyCommands,
     // Prefer typed AutoMesh commands only (per-processor)
     nijigenerate.commands.automesh.config.autoMeshTypedCommands,
+    nijigenerate.commands.vertex.define_mesh.commands,
+    nijigenerate.commands.model.set_deform_binding.commands,
 );
 pragma(msg, "[CT] AllCommandMaps includes typed AutoMesh only");
 

--- a/source/nijigenerate/commands/vertex/define_mesh.d
+++ b/source/nijigenerate/commands/vertex/define_mesh.d
@@ -1,0 +1,96 @@
+module nijigenerate.commands.vertex.define_mesh;
+
+import nijigenerate.commands.base;
+import nijigenerate.project : incSelectedNodes;
+import nijigenerate.viewport.common.mesh : IncMesh, applyMeshToTarget;
+import nijilive; // Node, Drawable
+import nijilive.math : vec2, vec3u;
+import std.algorithm : map, filter;
+import std.array : array;
+import std.conv : to;
+import std.exception : enforce;
+import i18n;
+
+/**
+    Define mesh topology for selected Drawables using provided arrays.
+
+    - vertices: flattened [x0,y0, x1,y1, ...]
+    - indices:  triangle indices (triplets) into vertex array
+*/
+class DefineMeshCommand : ExCommand!(
+    TW!(float[],  "vertices", "Flattened [x,y]* vertex coordinates"),
+    TW!(ushort[], "indices",  "Triangle indices (groups of 3)")
+) {
+    this(float[] verts, ushort[] inds) {
+        super(_("Define Mesh"), _("Apply a mesh defined by vertices and indices to selected nodes."), verts, inds);
+    }
+
+    override bool runnable(Context ctx) {
+        Node[] ns = ctx.hasNodes ? ctx.nodes : incSelectedNodes();
+        foreach (n; ns) if (cast(Drawable)n) return true;
+        return false;
+    }
+
+    // Do not expose as a usable shortcut (args must be provided programmatically)
+    override bool shortcutRunnable() { return false; }
+
+    override void run(Context ctx) {
+        if (!runnable(ctx)) return;
+
+        // No-op when verts/inds are not provided (or empty)
+        if (vertices is null || indices is null) return;
+        if (vertices.length == 0 || indices.length == 0) return;
+
+        // Basic validation
+        enforce(vertices.length % 2 == 0, "vertices length must be even (x,y pairs)");
+        enforce(indices.length % 3 == 0, "indices length must be a multiple of 3 (triangles)");
+
+        // Convert flattened float[] -> vec2[]
+        vec2[] vtx;
+        vtx.length = vertices.length / 2;
+        foreach (i; 0 .. vtx.length) {
+            vtx[i] = vec2(vertices[i*2 + 0], vertices[i*2 + 1]);
+        }
+
+        // Guard indices range
+        foreach (idx; indices) {
+            enforce(idx < vtx.length, "index out of range in indices array");
+        }
+
+        // Convert ushort[] (triplets) -> vec3u[]
+        vec3u[] tris;
+        tris.length = indices.length / 3;
+        foreach (i; 0 .. tris.length) {
+            tris[i] = vec3u(indices[i*3 + 0], indices[i*3 + 1], indices[i*3 + 2]);
+        }
+
+        // Resolve targets
+        Node[] ns = ctx.hasNodes ? ctx.nodes : incSelectedNodes();
+        auto targets = ns.filter!(n => cast(Drawable)n !is null).map!(n => cast(Drawable)n).array;
+        if (targets.length == 0) return;
+
+        // Apply to each target: build IncMesh from arrays, then applyMeshToTarget
+        foreach (t; targets) {
+            auto base = t.getMesh();
+            auto mesh = new IncMesh(base);
+            mesh.vertices.length = 0;
+            mesh.importVertsAndTris(vtx, tris);
+            mesh.refresh();
+
+            // For Drawable targets, applyMeshToTarget will use mesh.export_() for topology
+            applyMeshToTarget(t, mesh.vertices, &mesh);
+        }
+    }
+}
+
+enum VertexCommand {
+    DefineMesh,
+}
+
+Command[VertexCommand] commands;
+
+void ngInitCommands(T)() if (is(T == VertexCommand))
+{
+    // Register with benign defaults; actual args supplied at call-time (e.g., via MCP)
+    mixin(registerCommand!(VertexCommand.DefineMesh, null, null));
+}


### PR DESCRIPTION
- apply mesh from float[] verts + ushort[] inds
- SetDeformBinding: set binding values (deform or value) at keypoint 
- Auto-create bindings when missing (undoable)
- Type-driven (DeformationParameterBinding/ValueParameterBinding)
- Strict deform checks: even-length offsets, vertex-count match, deformable target
- No-ops on invalid/missing inputs; not runnable via shortcut
- Wire into commands package and AllCommandMaps