### PR TITLE
Make replacement Node configurable for LayerGroup in PSD/KRA file.

### DIFF
--- a/source/nijigenerate/core/settings.d
+++ b/source/nijigenerate/core/settings.d
@@ -65,6 +65,10 @@ void incSettingsLoad() {
     // Always ask the user whether to preserve the folder structure during import
     // also see incGetKeepLayerFolder()
     settings["KeepLayerFolder"] = "Ask";
+
+    // Replace LayerGroup with which node type on import when preserving structure
+    // Allowed values: "Node", "MeshGroup", "DynamicComposite"
+    settings["LayerGroupReplacement"] = "DynamicComposite";
 }
 
 /**

--- a/source/nijigenerate/core/settings.d
+++ b/source/nijigenerate/core/settings.d
@@ -68,7 +68,7 @@ void incSettingsLoad() {
 
     // Replace LayerGroup with which node type on import when preserving structure
     // Allowed values: "Node", "MeshGroup", "DynamicComposite"
-    settings["LayerGroupReplacement"] = "DynamicComposite";
+    settings["LayerGroupReplacement"] = "Node";
 }
 
 /**

--- a/source/nijigenerate/io/inimport.d
+++ b/source/nijigenerate/io/inimport.d
@@ -154,10 +154,17 @@ class LoadHandler(T) : ImportKeepHandler {
     bool load(AskKeepLayerFolder select) {
         switch (select) {
             case AskKeepLayerFolder.NotPreserve:
+                // Do not preserve structure; node type choice irrelevant
                 incImport!T(file, IncImportSettings(false));
                 return true;
             case AskKeepLayerFolder.Preserve:
-                incImport!T(file, IncImportSettings(true));
+                // Preserve structure; choose replacement node type for LayerGroup
+                IncImportSettings s;
+                s.keepStructure = true;
+                // Read from settings with sane default
+                import nijigenerate.core.settings : incSettingsGet;
+                s.layerGroupNodeType = incSettingsGet!string("LayerGroupReplacement", "Node");
+                incImport!T(file, s);
                 return true;
             case AskKeepLayerFolder.Cancel:
                 return false;

--- a/source/nijigenerate/windows/settings.d
+++ b/source/nijigenerate/windows/settings.d
@@ -240,6 +240,32 @@ protected:
                         }
                         endSection();
 
+                        beginSection(__("Layer group replacement")); {
+                            // Choose which node type replaces LayerGroup when preserving structure
+                            string[string] options = [
+                                "Node": _("Node"),
+                                "MeshGroup": _("MeshGroup"),
+                                "DynamicComposite": _("DynamicComposite")
+                            ];
+
+                            import nijigenerate.core.settings : incSettingsGet, incSettingsSet;
+                            string current = incSettingsGet!string("LayerGroupReplacement", "Node");
+                            string display = options.get(current, _("Node"));
+
+                            import std.string : toStringz;
+                            if (igBeginCombo(__("Replace LayerGroup with"), display.toStringz)) {
+                                foreach (key, label; options) {
+                                    if (igSelectable(label.toStringz, current == key)) {
+                                        incSettingsSet("LayerGroupReplacement", key);
+                                        current = key;
+                                    }
+                                }
+                                igEndCombo();
+                            }
+                            incTooltip(_("Node type to create for imported layer groups when preserving structure."));
+                        }
+                        endSection();
+
                         beginSection(__("On close project")); {
                             import nijigenerate.io.save;
                             string[string] option = incGetSaveProjectOption();


### PR DESCRIPTION
LayerGroup in PSD/KRA is replaced with "DynamicComposite" in v0.9 release. This patch make it configurable in the setting window.