### PR TITLE
feature: Brush has new option to fit deformation to target teacher image automatically.

### DIFF
--- a/source/nijigenerate/commands/puppet/view.d
+++ b/source/nijigenerate/commands/puppet/view.d
@@ -87,12 +87,12 @@ class ToggleDifferenceAggregationCommand : ExCommand!() {
 
     override
     void run(Context ctx) {
-        incDifferenceAggregationDebugEnabled = !incDifferenceAggregationDebugEnabled;
-        if (!incDifferenceAggregationDebugEnabled) {
-            incDifferenceAggregationResolvedIndex = size_t.max;
-            incDifferenceAggregationResultValid = false;
-            incDifferenceAggregationResult = DifferenceEvaluationResult.init;
-            incDifferenceAggregationResultSerial = 0;
+        ngDifferenceAggregationDebugEnabled = !ngDifferenceAggregationDebugEnabled;
+        if (!ngDifferenceAggregationDebugEnabled) {
+            ngDifferenceAggregationResolvedIndex = size_t.max;
+            ngDifferenceAggregationResultValid = false;
+            ngDifferenceAggregationResult = DifferenceEvaluationResult.init;
+            ngDifferenceAggregationResultSerial = 0;
             inSetDifferenceAggregationEnabled(false);
         }
     }

--- a/source/nijigenerate/commands/puppet/view.d
+++ b/source/nijigenerate/commands/puppet/view.d
@@ -3,7 +3,7 @@ module nijigenerate.commands.puppet.view;
 import nijigenerate.commands.base;
 import nijigenerate.core.window;
 import nijilive;
-import nijilive.core.renderpipeline : DifferenceEvaluationResult;
+import nijilive.core.diff_collect : DifferenceEvaluationResult;
 import tinyfiledialogs;
 import nijigenerate.io;
 import i18n;
@@ -92,6 +92,7 @@ class ToggleDifferenceAggregationCommand : ExCommand!() {
             incDifferenceAggregationResolvedIndex = size_t.max;
             incDifferenceAggregationResultValid = false;
             incDifferenceAggregationResult = DifferenceEvaluationResult.init;
+            incDifferenceAggregationResultSerial = 0;
             inSetDifferenceAggregationEnabled(false);
         }
     }

--- a/source/nijigenerate/commands/puppet/view.d
+++ b/source/nijigenerate/commands/puppet/view.d
@@ -3,6 +3,7 @@ module nijigenerate.commands.puppet.view;
 import nijigenerate.commands.base;
 import nijigenerate.core.window;
 import nijilive;
+import nijilive.core.renderpipeline : DifferenceEvaluationResult;
 import tinyfiledialogs;
 import nijigenerate.io;
 import i18n;
@@ -81,11 +82,27 @@ class ShowStatusForNerdsCommand : ExCommand!() {
     }
 }
 
+class ToggleDifferenceAggregationCommand : ExCommand!() {
+    this() { super(_("Difference Aggregation Debug"), _("Toggle GPU difference aggregation for the selected node.")); }
+
+    override
+    void run(Context ctx) {
+        incDifferenceAggregationDebugEnabled = !incDifferenceAggregationDebugEnabled;
+        if (!incDifferenceAggregationDebugEnabled) {
+            incDifferenceAggregationResolvedIndex = size_t.max;
+            incDifferenceAggregationResultValid = false;
+            incDifferenceAggregationResult = DifferenceEvaluationResult.init;
+            inSetDifferenceAggregationEnabled(false);
+        }
+    }
+}
+
 enum ViewCommand {
     SetDefaultLayout,
     ShowSaveScreenshotDialog,
     SaveScreenshot,
     ShowStatusForNerds,
+    ToggleDifferenceAggregation,
 }
 
 

--- a/source/nijigenerate/core/window.d
+++ b/source/nijigenerate/core/window.d
@@ -17,6 +17,7 @@ import nijigenerate.widgets.dialog;
 import nijigenerate.widgets.modal;
 import nijigenerate.widgets.button;
 import nijilive;
+import nijilive.core.renderpipeline : DifferenceEvaluationResult;
 import nijigenerate.backend.gl;
 import nijigenerate.io.autosave;
 import nijigenerate.io.save;
@@ -132,6 +133,11 @@ package {
 }
 
 bool incShowStatsForNerds;
+bool incDifferenceAggregationDebugEnabled;
+size_t incDifferenceAggregationTargetIndex;
+size_t incDifferenceAggregationResolvedIndex = size_t.max;
+DifferenceEvaluationResult incDifferenceAggregationResult;
+bool incDifferenceAggregationResultValid;
 
 
 bool incIsWayland() {

--- a/source/nijigenerate/core/window.d
+++ b/source/nijigenerate/core/window.d
@@ -116,6 +116,9 @@ package {
     
     ImVec4[ImGuiCol.COUNT] incDarkModeColors;
     ImVec4[ImGuiCol.COUNT] incLightModeColors;
+    bool viewportBackgroundOverrideActive;
+    ImVec4 viewportBackgroundOverrideColor;
+    ImVec4 viewportBackgroundStoredColor;
 
     SDL_Window* tryCreateWindow(string title, SDL_WindowFlags flags) {
         auto w = SDL_CreateWindow(
@@ -380,7 +383,7 @@ SDL_Window* incGetWindowPtr() {
 void incRefreshWindowTitle() {
     import std.string : toStringz;
     if (windowSubtitle.length > 0) {
-        string mark = incIsProjectModified() ? " ●" : "";
+        string mark = incIsProjectModified() ? " *" : "";
         SDL_SetWindowTitle(window, ("nijigenerate - " ~ windowSubtitle ~ mark).toStringz);
     } else {
         SDL_SetWindowTitle(window, "nijigenerate");
@@ -877,13 +880,73 @@ void incDebugImGuiState(string msg, int indent = 0) {
     Resets the clear color
 */
 void incResetClearColor() {
-    if (incGetDarkMode()) {
-        inSetClearColor(0, 0, 0, 1);
-    } else {
-        inSetClearColor(1, 1, 1, 1);
+    ImVec4 defaultColor = incGetDarkMode() ? ImVec4(0, 0, 0, 1) : ImVec4(1, 1, 1, 1);
+    inSetClearColor(defaultColor.x, defaultColor.y, defaultColor.z, defaultColor.w);
+    if (viewportBackgroundOverrideActive) {
+        viewportBackgroundStoredColor = defaultColor;
+        inSetClearColor(
+            viewportBackgroundOverrideColor.x,
+            viewportBackgroundOverrideColor.y,
+            viewportBackgroundOverrideColor.z,
+            viewportBackgroundOverrideColor.w,
+        );
     }
 }
 
+
+bool incViewportHasTemporaryBackgroundColor() {
+    return viewportBackgroundOverrideActive;
+}
+
+void incViewportGetBackgroundColor(ref ImVec4 color) {
+    if (viewportBackgroundOverrideActive) {
+        color = viewportBackgroundOverrideColor;
+    } else {
+        inGetClearColor(color.x, color.y, color.z, color.w);
+    }
+}
+
+ImVec4 incViewportGetBackgroundColor() {
+    ImVec4 color;
+    incViewportGetBackgroundColor(color);
+    return color;
+}
+
+/**
+    Temporarily overrides the viewport background color until cleared.
+*/
+void incViewportSetTemporaryBackgroundColor(float r, float g, float b, float a = 1.0f) {
+    if (!viewportBackgroundOverrideActive) {
+        inGetClearColor(
+            viewportBackgroundStoredColor.x,
+            viewportBackgroundStoredColor.y,
+            viewportBackgroundStoredColor.z,
+            viewportBackgroundStoredColor.w,
+        );
+        viewportBackgroundOverrideActive = true;
+    }
+    viewportBackgroundOverrideColor = ImVec4(r, g, b, a);
+    inSetClearColor(r, g, b, a);
+}
+
+void incViewportSetTemporaryBackgroundColor(ImVec4 color) {
+    incViewportSetTemporaryBackgroundColor(color.x, color.y, color.z, color.w);
+}
+
+/**
+    Restores the viewport background color to the stored value.
+*/
+void incViewportClearTemporaryBackgroundColor() {
+    if (!viewportBackgroundOverrideActive)
+        return;
+    inSetClearColor(
+        viewportBackgroundStoredColor.x,
+        viewportBackgroundStoredColor.y,
+        viewportBackgroundStoredColor.z,
+        viewportBackgroundStoredColor.w,
+    );
+    viewportBackgroundOverrideActive = false;
+}
 /**
     Gets whether nijigenerate has requested the app to close
 */
@@ -906,3 +969,4 @@ void incExit() {
     incSettingsSet!bool("WinMax", (flags & SDL_WINDOW_MAXIMIZED) > 0);
     incReleaseLockfile();
 }
+

--- a/source/nijigenerate/core/window.d
+++ b/source/nijigenerate/core/window.d
@@ -133,12 +133,12 @@ package {
 }
 
 bool incShowStatsForNerds;
-bool incDifferenceAggregationDebugEnabled;
-size_t incDifferenceAggregationTargetIndex;
-size_t incDifferenceAggregationResolvedIndex = size_t.max;
-DifferenceEvaluationResult incDifferenceAggregationResult;
-bool incDifferenceAggregationResultValid;
-ulong incDifferenceAggregationResultSerial;
+bool ngDifferenceAggregationDebugEnabled;
+size_t ngDifferenceAggregationTargetIndex;
+size_t ngDifferenceAggregationResolvedIndex = size_t.max;
+DifferenceEvaluationResult ngDifferenceAggregationResult;
+bool ngDifferenceAggregationResultValid;
+ulong ngDifferenceAggregationResultSerial;
 
 
 bool incIsWayland() {

--- a/source/nijigenerate/core/window.d
+++ b/source/nijigenerate/core/window.d
@@ -17,7 +17,7 @@ import nijigenerate.widgets.dialog;
 import nijigenerate.widgets.modal;
 import nijigenerate.widgets.button;
 import nijilive;
-import nijilive.core.renderpipeline : DifferenceEvaluationResult;
+import nijilive.core.diff_collect : DifferenceEvaluationResult;
 import nijigenerate.backend.gl;
 import nijigenerate.io.autosave;
 import nijigenerate.io.save;
@@ -138,6 +138,7 @@ size_t incDifferenceAggregationTargetIndex;
 size_t incDifferenceAggregationResolvedIndex = size_t.max;
 DifferenceEvaluationResult incDifferenceAggregationResult;
 bool incDifferenceAggregationResultValid;
+ulong incDifferenceAggregationResultSerial;
 
 
 bool incIsWayland() {

--- a/source/nijigenerate/panels/viewport.d
+++ b/source/nijigenerate/panels/viewport.d
@@ -12,6 +12,7 @@ import nijigenerate.windows;
 import nijigenerate.widgets;
 import nijigenerate.widgets.viewport;
 import nijigenerate.core;
+import nijigenerate.core.window : incViewportGetBackgroundColor;
 import nijigenerate.core.colorbleed;
 import nijigenerate.panels;
 import nijigenerate.actions;
@@ -130,8 +131,7 @@ protected:
             int width, height;
             inGetViewport(width, height);
 
-            ImVec4 color;
-            inGetClearColor(color.x, color.y, color.z, color.w);
+            ImVec4 color = incViewportGetBackgroundColor();
 
             ImRect rect = ImRect(
                 ImVec2(
@@ -148,7 +148,7 @@ protected:
             ImDrawList_AddRectFilled(drawList,
                 rect.Min,
                 rect.Max,
-                igGetColorU32(ImVec4(0,0,0,1)),
+                igGetColorU32(color),
             );
 
             // Render our viewport
@@ -291,7 +291,7 @@ protected:
                 }
                 if (incViewportTargetZoom != 1) {
                     igSameLine(0, 8);
-                    if (incButtonColored("", ImVec2(0, 0))) {
+                    if (incButtonColored("Reset Zoom", ImVec2(0, 0), ImVec4.init)) {
                         auto ctx = new Context;
                         if (incActivePuppet() !is null) ctx.puppet = incActivePuppet();
                         cmd!(ViewportCommand.ResetViewportZoom)(ctx);
@@ -305,7 +305,7 @@ protected:
                 incText("x = %.2f y = %.2f".format(incViewportTargetPosition.x, incViewportTargetPosition.y));
                 if (incViewportTargetPosition != vec2(0)) {
                     igSameLine(0, 8);
-                    if (incButtonColored("##2", ImVec2(0, 0))) {
+                    if (incButtonColored("Reset Pos", ImVec2(0, 0), ImVec4.init)) {
                         auto ctx = new Context;
                         if (incActivePuppet() !is null) ctx.puppet = incActivePuppet();
                         cmd!(ViewportCommand.ResetViewportPosition)(ctx);
@@ -325,7 +325,7 @@ protected:
 
         if (igBeginChild("##ModelControl", ImVec2(0, currSize.y), false, flags.NoScrollbar)) {
 
-            if (incButtonColored("\ue8d4", ImVec2(32, 0), incShouldMirrorViewport ? ImVec4.init : ImVec4(0.6f, 0.6f, 0.6f, 1f))) {
+            if (incButtonColored("Mirror", ImVec2(32, 0), incShouldMirrorViewport ? ImVec4.init : ImVec4(0.6f, 0.6f, 0.6f, 1f))) {
                 auto ctx = new Context;
                 if (incActivePuppet() !is null) ctx.puppet = incActivePuppet();
                 cmd!(ViewportCommand.ToggleMirrorView)(ctx);
@@ -335,7 +335,7 @@ protected:
             igSameLine(0, 0);
 
             auto onion = OnionSlice.singleton;
-            if (incButtonColored("\ue71c", ImVec2(32, 0), onion.enabled? ImVec4.init: ImVec4(0.6, 0.6, 0.6, 1))) {
+            if (incButtonColored("Onion", ImVec2(32, 0), onion.enabled ? ImVec4.init : ImVec4(0.6f, 0.6f, 0.6f, 1f))) {
                 auto ctx = new Context;
                 cmd!(ViewportCommand.ToggleOnionSlice)(ctx);
             }
@@ -343,7 +343,7 @@ protected:
 
             igSameLine();
 
-            if (incButtonColored("", ImVec2(32, 0), incActivePuppet().enableDrivers ? ImVec4.init : ImVec4(0.6f, 0.6f, 0.6f, 1f))) {
+            if (incButtonColored("Physics", ImVec2(32, 0), incActivePuppet().enableDrivers ? ImVec4.init : ImVec4(0.6f, 0.6f, 0.6f, 1f))) {
                 auto ctx = new Context;
                 if (incActivePuppet() !is null) ctx.puppet = incActivePuppet();
                 cmd!(ViewportCommand.TogglePhysics)(ctx);
@@ -352,7 +352,7 @@ protected:
 
             igSameLine(0, 0);
 
-            if (incButtonColored("", ImVec2(32, 0), incShouldPostProcess ? ImVec4.init : ImVec4(0.6f, 0.6f, 0.6f, 1f))) {
+            if (incButtonColored("PostFX", ImVec2(32, 0), incShouldPostProcess ? ImVec4.init : ImVec4(0.6f, 0.6f, 0.6f, 1f))) {
                 auto ctx = new Context;
                 if (incActivePuppet() !is null) ctx.puppet = incActivePuppet();
                 cmd!(ViewportCommand.TogglePostProcess)(ctx);
@@ -361,7 +361,7 @@ protected:
 
             igSameLine();
 
-            if (incButtonColored("", ImVec2(32, 0), ImVec4.init)) {
+            if (incButtonColored("Reset Phys", ImVec2(32, 0), ImVec4.init)) {
                 auto ctx = new Context;
                 if (incActivePuppet() !is null) ctx.puppet = incActivePuppet();
                 cmd!(ViewportCommand.ResetPhysics)(ctx);
@@ -370,7 +370,7 @@ protected:
 
             igSameLine(0, 0);
 
-            if (incButtonColored("", ImVec2(32, 0), ImVec4.init)) {
+            if (incButtonColored("Reset Params", ImVec2(32, 0), ImVec4.init)) {
                 auto ctx = new Context;
                 if (incActivePuppet() !is null) ctx.puppet = incActivePuppet();
                 cmd!(ViewportCommand.ResetParameters)(ctx);
@@ -379,7 +379,7 @@ protected:
             
             igSameLine();
 
-            if (incButtonColored("", ImVec2(32, 0), ImVec4.init)) {
+            if (incButtonColored("Flip Pair", ImVec2(32, 0), ImVec4.init)) {
                 auto ctx = new Context;
                 if (incActivePuppet() !is null) ctx.puppet = incActivePuppet();
                 cmd!(ViewportCommand.OpenFlipPairWindow)(ctx);
@@ -388,7 +388,7 @@ protected:
             
             igSameLine(0, 0);
 
-            if (incButtonColored("", ImVec2(32, 0))) {
+            if (incButtonColored("Automesh", ImVec2(32, 0), ImVec4.init)) {
                 auto ctx = new Context;
                 if (incActivePuppet() !is null) ctx.puppet = incActivePuppet();
                 cmd!(ViewportCommand.OpenAutomeshBatching)(ctx);
@@ -413,3 +413,4 @@ public:
 }
 
 mixin incPanel!ViewportPanel;
+

--- a/source/nijigenerate/viewport/base.d
+++ b/source/nijigenerate/viewport/base.d
@@ -10,10 +10,10 @@ import nijigenerate.core.dpi;
 import nijigenerate.actions;
 import nijigenerate.project;
 import nijigenerate.core.window :
-    incDifferenceAggregationResolvedIndex,
-    incDifferenceAggregationResult,
-    incDifferenceAggregationResultValid,
-    incDifferenceAggregationResultSerial;
+    ngDifferenceAggregationResolvedIndex,
+    ngDifferenceAggregationResult,
+    ngDifferenceAggregationResultValid,
+    ngDifferenceAggregationResultSerial;
 import nijigenerate.viewport.model;
 import nijigenerate.viewport.model.deform;
 import nijigenerate.viewport.vertex;
@@ -171,25 +171,25 @@ class MainViewport : DelegationViewport {
             if (inEvaluateDifferenceAggregation(texture, viewportWidth, viewportHeight)) {
                 DifferenceEvaluationResult result;
                 if (inFetchDifferenceAggregationResult(result)) {
-                    incDifferenceAggregationResult = result;
-                    incDifferenceAggregationResultValid = true;
-                    incDifferenceAggregationResultSerial++;
+                    ngDifferenceAggregationResult = result;
+                    ngDifferenceAggregationResultValid = true;
+                    ngDifferenceAggregationResultSerial++;
                 } else {
                     // Keep the previous result when fetch fails so transient stalls
                     // (for example when the target selection changes) do not cause
                     // the visible difference metric to flicker.
-                    // Leave incDifferenceAggregationResult unchanged and preserve
+                    // Leave ngDifferenceAggregationResult unchanged and preserve
                     // the last-known validity state.
                 }
             } else {
-                incDifferenceAggregationResult = DifferenceEvaluationResult.init;
-                incDifferenceAggregationResultValid = false;
-                incDifferenceAggregationResultSerial = 0;
+                ngDifferenceAggregationResult = DifferenceEvaluationResult.init;
+                ngDifferenceAggregationResultValid = false;
+                ngDifferenceAggregationResultSerial = 0;
             }
         } else {
-            incDifferenceAggregationResult = DifferenceEvaluationResult.init;
-            incDifferenceAggregationResultValid = false;
-            incDifferenceAggregationResultSerial = 0;
+            ngDifferenceAggregationResult = DifferenceEvaluationResult.init;
+            ngDifferenceAggregationResultValid = false;
+            ngDifferenceAggregationResultSerial = 0;
         }
 
         if (incShouldPostProcess) {
@@ -252,7 +252,7 @@ private:
     }
 
     bool prepareDifferenceAggregation(Camera camera) {
-        incDifferenceAggregationResolvedIndex = size_t.max;
+        ngDifferenceAggregationResolvedIndex = size_t.max;
 
         if (!incBrushHasTeacherPart()) {
             inSetDifferenceAggregationEnabled(false);

--- a/source/nijigenerate/viewport/common/mesheditor/brushstate.d
+++ b/source/nijigenerate/viewport/common/mesheditor/brushstate.d
@@ -1,0 +1,23 @@
+module nijigenerate.viewport.common.mesheditor.brushstate;
+
+import nijilive.core.nodes.part : Part;
+
+alias TeacherPart = Part;
+
+private __gshared TeacherPart brushTeacherPart;
+
+TeacherPart incBrushGetTeacherPart() {
+    return brushTeacherPart;
+}
+
+void incBrushSetTeacherPart(TeacherPart part) {
+    brushTeacherPart = part;
+}
+
+void incBrushClearTeacherPart() {
+    brushTeacherPart = null;
+}
+
+bool incBrushHasTeacherPart() {
+    return brushTeacherPart !is null;
+}

--- a/source/nijigenerate/viewport/common/mesheditor/brushstate.d
+++ b/source/nijigenerate/viewport/common/mesheditor/brushstate.d
@@ -1,6 +1,6 @@
 module nijigenerate.viewport.common.mesheditor.brushstate;
 
-import nijilive.core.nodes.part : Part;
+import nijilive.core.nodes.part : Part, BlendMode;
 import nijigenerate.core.window : incViewportSetTemporaryBackgroundColor, incViewportClearTemporaryBackgroundColor;
 
 alias TeacherPart = Part;
@@ -8,8 +8,11 @@ alias TeacherPart = Part;
 private __gshared TeacherPart brushTeacherPart;
 private __gshared bool brushTeacherPartVisibilityOverridden;
 private __gshared bool brushTeacherPartPreviousEnabled;
+private __gshared BlendMode brushTeacherPartPreviousBlendMode;
+private __gshared bool brushTeacherPartBlendModeOverridden;
 
 TeacherPart incBrushGetTeacherPart() {
+    enforceTeacherPartBlendMode(brushTeacherPart);
     return brushTeacherPart;
 }
 
@@ -22,6 +25,7 @@ void incBrushSetTeacherPart(TeacherPart part) {
                 part.setEnabled(true);
                 brushTeacherPartVisibilityOverridden = true;
             }
+            enforceTeacherPartBlendMode(part);
             incViewportSetTemporaryBackgroundColor(0.0f, 0.0f, 0.0f, 1.0f);
         } else {
             incViewportClearTemporaryBackgroundColor();
@@ -29,10 +33,16 @@ void incBrushSetTeacherPart(TeacherPart part) {
         return;
     }
 
-    if (brushTeacherPart !is null && brushTeacherPartVisibilityOverridden) {
-        brushTeacherPart.setEnabled(brushTeacherPartPreviousEnabled);
+    if (brushTeacherPart !is null) {
+        if (brushTeacherPartVisibilityOverridden) {
+            brushTeacherPart.setEnabled(brushTeacherPartPreviousEnabled);
+        }
+        if (brushTeacherPartBlendModeOverridden) {
+            brushTeacherPart.blendingMode = brushTeacherPartPreviousBlendMode;
+        }
     }
     brushTeacherPartVisibilityOverridden = false;
+    brushTeacherPartBlendModeOverridden = false;
 
     brushTeacherPart = part;
 
@@ -42,9 +52,21 @@ void incBrushSetTeacherPart(TeacherPart part) {
             part.setEnabled(true);
             brushTeacherPartVisibilityOverridden = true;
         }
+        enforceTeacherPartBlendMode(part);
         incViewportSetTemporaryBackgroundColor(0.0f, 0.0f, 0.0f, 1.0f);
     } else {
         incViewportClearTemporaryBackgroundColor();
+    }
+}
+
+private void enforceTeacherPartBlendMode(TeacherPart part) {
+    if (part is null)
+        return;
+
+    if (part.blendingMode != BlendMode.Difference) {
+        brushTeacherPartPreviousBlendMode = part.blendingMode;
+        brushTeacherPartBlendModeOverridden = true;
+        part.blendingMode = BlendMode.Difference;
     }
 }
 

--- a/source/nijigenerate/viewport/common/mesheditor/brushstate.d
+++ b/source/nijigenerate/viewport/common/mesheditor/brushstate.d
@@ -1,21 +1,55 @@
 module nijigenerate.viewport.common.mesheditor.brushstate;
 
 import nijilive.core.nodes.part : Part;
+import nijigenerate.core.window : incViewportSetTemporaryBackgroundColor, incViewportClearTemporaryBackgroundColor;
 
 alias TeacherPart = Part;
 
 private __gshared TeacherPart brushTeacherPart;
+private __gshared bool brushTeacherPartVisibilityOverridden;
+private __gshared bool brushTeacherPartPreviousEnabled;
 
 TeacherPart incBrushGetTeacherPart() {
     return brushTeacherPart;
 }
 
 void incBrushSetTeacherPart(TeacherPart part) {
+    if (part is brushTeacherPart) {
+        if (part !is null) {
+            bool currentlyEnabled = part.getEnabled();
+            if (!currentlyEnabled) {
+                brushTeacherPartPreviousEnabled = false;
+                part.setEnabled(true);
+                brushTeacherPartVisibilityOverridden = true;
+            }
+            incViewportSetTemporaryBackgroundColor(0.0f, 0.0f, 0.0f, 1.0f);
+        } else {
+            incViewportClearTemporaryBackgroundColor();
+        }
+        return;
+    }
+
+    if (brushTeacherPart !is null && brushTeacherPartVisibilityOverridden) {
+        brushTeacherPart.setEnabled(brushTeacherPartPreviousEnabled);
+    }
+    brushTeacherPartVisibilityOverridden = false;
+
     brushTeacherPart = part;
+
+    if (part !is null) {
+        brushTeacherPartPreviousEnabled = part.getEnabled();
+        if (!brushTeacherPartPreviousEnabled) {
+            part.setEnabled(true);
+            brushTeacherPartVisibilityOverridden = true;
+        }
+        incViewportSetTemporaryBackgroundColor(0.0f, 0.0f, 0.0f, 1.0f);
+    } else {
+        incViewportClearTemporaryBackgroundColor();
+    }
 }
 
 void incBrushClearTeacherPart() {
-    brushTeacherPart = null;
+    incBrushSetTeacherPart(null);
 }
 
 bool incBrushHasTeacherPart() {

--- a/source/nijigenerate/viewport/common/mesheditor/tools/brush.d
+++ b/source/nijigenerate/viewport/common/mesheditor/tools/brush.d
@@ -413,29 +413,6 @@ class BrushTool : NodeSelect {
                     tileValues[i] = double.infinity;
                 }
             }
-
-            static size_t tileDebugCounter;
-            if (tileDebugCounter < 10) {
-                double minValue = double.infinity;
-                double maxValue = -double.infinity;
-                foreach (value; tileValues) {
-                    if (isFinite(value)) {
-                        if (value < minValue) minValue = value;
-                        if (value > maxValue) maxValue = value;
-                    }
-                }
-                stderr.writefln("[diff] brush sample #%s global=%.6f min=%.6f max=%.6f", tileDebugCounter, globalScore, minValue, maxValue);
-                foreach (int ty; 0 .. TileColumns) {
-                    string line;
-                    foreach (int tx; 0 .. TileColumns) {
-                        size_t idx = cast(size_t)ty * TileColumns + tx;
-                        double value = tileValues[idx];
-                        line ~= isFinite(value) ? format(" %8.5f", value) : "    nan";
-                    }
-                    stderr.writefln("[diff] brush row %02d:%s", ty, line);
-                }
-                tileDebugCounter++;
-            }
         }
 
         mat4 combinedMatrix = computeCombinedMatrix(impl);

--- a/source/nijigenerate/viewport/common/mesheditor/tools/brush.d
+++ b/source/nijigenerate/viewport/common/mesheditor/tools/brush.d
@@ -895,7 +895,7 @@ class ToolInfoImpl(T: BrushTool) : ToolInfoBase!(T) {
         igPushStyleVar(ImGuiStyleVar.WindowPadding, ImVec2(4, 4));
         auto brushTool = cast(BrushTool)(editors.length == 0 ? null: editors.values()[0].getTool());
             igBeginGroup();
-                if (incButtonColored("", ImVec2(0, 0), (brushTool !is null && !brushTool.getFlow())? colorUndefined : ImVec4(0.6, 0.6, 0.6, 1))) { // path definition
+                if (incButtonColored("\ue39e", ImVec2(0, 0), (brushTool !is null && !brushTool.getFlow()) ? colorUndefined : ImVec4(0.6, 0.6, 0.6, 1))) { // drag mode toggle
                     foreach (e; editors) {
                         auto bt = cast(BrushTool)(e.getTool());
                         if (bt)
@@ -905,7 +905,7 @@ class ToolInfoImpl(T: BrushTool) : ToolInfoBase!(T) {
                 incTooltip(_("Drag mode"));
 
                 igSameLine(0, 0);
-                if (incButtonColored("", ImVec2(0, 0), (brushTool !is null && brushTool.getFlow())? colorUndefined : ImVec4(0.6, 0.6, 0.6, 1))) { // path definition
+                if (incButtonColored("\ue3a2", ImVec2(0, 0), (brushTool !is null && brushTool.getFlow()) ? colorUndefined : ImVec4(0.6, 0.6, 0.6, 1))) { // flow mode toggle
                     foreach (e; editors) {
                         auto bt = cast(BrushTool)(e.getTool());
                         if (bt)
@@ -941,7 +941,7 @@ class ToolInfoImpl(T: BrushTool) : ToolInfoBase!(T) {
         return false;
     }
     override VertexToolMode mode() { return VertexToolMode.Brush; };
-    override string icon() { return "";}
+    override string icon() { return "\ue3ae";}
     override string description() { return _("Brush Tool");}
 }
 
@@ -951,7 +951,8 @@ private void drawTeacherTargetOption(BrushTool brushTool) {
     Part teacher = incBrushGetTeacherPart();
 
     igSameLine(0, 4);
-    ImVec2 previewSize = ImVec2(72, 72);
+    ImVec2 previewSize = ImVec2(64, 64);
+    ImVec2 previewSizeNone = ImVec2(64, 32);
     igPushID("BRUSH_TEACHER_TARGET");
         if (teacher !is null && teacher.textures.length > 0 && teacher.textures[0]) {
             incTextureSlotUntitled("TeacherPreview", teacher.textures[0], previewSize, 32, ImGuiWindowFlags.None, false);
@@ -959,8 +960,8 @@ private void drawTeacherTargetOption(BrushTool brushTool) {
             ImVec4 bg = *igGetStyleColorVec4(ImGuiCol.ChildBg);
             bg.w = 0.15f;
             igPushStyleColor(ImGuiCol.ChildBg, bg);
-            igBeginChild("Teacher Part", previewSize, true, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse | ImGuiWindowFlags.AlwaysUseWindowPadding);
-                incText(_("Teacher Part"));
+            igBeginChild("Teacher Part", previewSizeNone, true, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse | ImGuiWindowFlags.AlwaysUseWindowPadding);
+                igText(_("Teacher").toStringz);
             igEndChild();
             igPopStyleColor();
         }

--- a/source/nijigenerate/viewport/common/mesheditor/tools/brush.d
+++ b/source/nijigenerate/viewport/common/mesheditor/tools/brush.d
@@ -36,9 +36,9 @@ import std.range : iota;
 import std.stdio : stderr, writefln;
 import nijigenerate.core.dpi : incGetUIScale;
 import nijigenerate.core.window :
-    incDifferenceAggregationResult,
-    incDifferenceAggregationResultValid,
-    incDifferenceAggregationResultSerial;
+    ngDifferenceAggregationResult,
+    ngDifferenceAggregationResultValid,
+    ngDifferenceAggregationResultSerial;
 
 
 enum TileColumns = 16;
@@ -112,7 +112,7 @@ class BrushTool : NodeSelect {
         strokeVertices.length = 0;
         waitingForResult = false;
         pendingSampleParameter = 1.0f;
-        lastResultSerial = incDifferenceAggregationResultSerial;
+        lastResultSerial = ngDifferenceAggregationResultSerial;
         bestScores.length = 0;
         bestParameters.length = 0;
         activeRegionValid = false;
@@ -138,10 +138,10 @@ class BrushTool : NodeSelect {
 
     void captureBaselineDifference() {
         baselineTileValues.length = TileCount;
-        if (incDifferenceAggregationResultValid) {
+        if (ngDifferenceAggregationResultValid) {
             foreach (i; 0 .. TileCount) {
-                double count = incDifferenceAggregationResult.tileCounts[i];
-                double value = count > 0 ? incDifferenceAggregationResult.tileTotals[i] / count : double.infinity;
+                double count = ngDifferenceAggregationResult.tileCounts[i];
+                double value = count > 0 ? ngDifferenceAggregationResult.tileTotals[i] / count : double.infinity;
                 baselineTileValues[i] = value;
             }
             baselineGlobalScore = computeGlobalDifferenceMetric();
@@ -375,7 +375,7 @@ class BrushTool : NodeSelect {
 
         waitingForResult = false;
         pendingSampleParameter = 1.0f;
-        lastResultSerial = incDifferenceAggregationResultSerial;
+        lastResultSerial = ngDifferenceAggregationResultSerial;
         activeRegionValid = false;
 
         if (strokeVertices.length == 0) {
@@ -487,9 +487,9 @@ class BrushTool : NodeSelect {
         bool anyFinite = false;
         if (activeRegionValid) {
             foreach (i; 0 .. TileCount) {
-                double count = incDifferenceAggregationResult.tileCounts[i];
+                double count = ngDifferenceAggregationResult.tileCounts[i];
                 if (count > 0) {
-                    tileValues[i] = incDifferenceAggregationResult.tileTotals[i] / count;
+                    tileValues[i] = ngDifferenceAggregationResult.tileTotals[i] / count;
                     anyFinite = true;
                 } else {
                     tileValues[i] = double.infinity;
@@ -654,18 +654,18 @@ class BrushTool : NodeSelect {
     }
 
     double computeGlobalDifferenceMetric() const {
-        if (!incDifferenceAggregationResultValid)
+        if (!ngDifferenceAggregationResultValid)
             return double.infinity;
 
-        if (incDifferenceAggregationResult.alpha > 0) {
-            return incDifferenceAggregationResult.total / incDifferenceAggregationResult.alpha;
+        if (ngDifferenceAggregationResult.alpha > 0) {
+            return ngDifferenceAggregationResult.total / ngDifferenceAggregationResult.alpha;
         }
         double sumTotals = 0;
         double sumWeights = 0;
-        foreach (value; incDifferenceAggregationResult.tileTotals) {
+        foreach (value; ngDifferenceAggregationResult.tileTotals) {
             sumTotals += value;
         }
-        foreach (value; incDifferenceAggregationResult.tileCounts) {
+        foreach (value; ngDifferenceAggregationResult.tileCounts) {
             sumWeights += value;
         }
 
@@ -693,7 +693,7 @@ class BrushTool : NodeSelect {
             return false;
         }
 
-        if (!baselineValid && incDifferenceAggregationResultValid) {
+        if (!baselineValid && ngDifferenceAggregationResultValid) {
             captureBaselineDifference();
         }
 
@@ -709,8 +709,8 @@ class BrushTool : NodeSelect {
         }
 
         if (waitingForResult) {
-            if (incDifferenceAggregationResultValid && incDifferenceAggregationResultSerial != lastResultSerial) {
-                lastResultSerial = incDifferenceAggregationResultSerial;
+            if (ngDifferenceAggregationResultValid && ngDifferenceAggregationResultSerial != lastResultSerial) {
+                lastResultSerial = ngDifferenceAggregationResultSerial;
                 activeRegion = inGetDifferenceAggregationRegion();
                 activeRegionValid = activeRegion.width > 0 && activeRegion.height > 0;
                 double aggregate = updateScoresForSample(impl);
@@ -755,7 +755,7 @@ class BrushTool : NodeSelect {
         if (currentSampleIndex < currentStageSampleCount) {
             pendingSampleParameter = computeSampleParameter(currentSampleIndex++);
             setStrokeParameter(impl, pendingSampleParameter);
-            lastResultSerial = incDifferenceAggregationResultSerial;
+            lastResultSerial = ngDifferenceAggregationResultSerial;
             impl.refreshMesh();
             waitingForResult = true;
             return true;
@@ -765,8 +765,8 @@ class BrushTool : NodeSelect {
         return true;
     }
 
-    void drawDifferenceDiagnostics(IncMeshEditorOne impl) {
-        if (!baselineValid && incDifferenceAggregationResultValid) {
+    void dbgDrawDifferenceDiagnostics(IncMeshEditorOne impl) {
+        if (!baselineValid && ngDifferenceAggregationResultValid) {
             captureBaselineDifference();
         }
 
@@ -803,7 +803,7 @@ class BrushTool : NodeSelect {
         mat4 viewProj = camera.matrix();
         mat4 invViewProj = viewProj.inverse();
 
-        double currentGlobal = incDifferenceAggregationResultValid ? computeGlobalDifferenceMetric() : baselineGlobalScore;
+        double currentGlobal = ngDifferenceAggregationResultValid ? computeGlobalDifferenceMetric() : baselineGlobalScore;
         const double epsilon = 1e-6;
         vec4 improveColor = vec4(0, 1, 0, 0.8f);
         vec4 worsenColor = vec4(1, 0, 0, 0.8f);
@@ -820,9 +820,9 @@ class BrushTool : NodeSelect {
                 if (!isFinite(baselineValue)) baselineValue = baselineGlobalScore;
 
                 double currentValue;
-                if (incDifferenceAggregationResultValid) {
-                    double count = incDifferenceAggregationResult.tileCounts[idx];
-                    currentValue = count > 0 ? incDifferenceAggregationResult.tileTotals[idx] / count : currentGlobal;
+                if (ngDifferenceAggregationResultValid) {
+                    double count = ngDifferenceAggregationResult.tileCounts[idx];
+                    currentValue = count > 0 ? ngDifferenceAggregationResult.tileTotals[idx] / count : currentGlobal;
                 } else {
                     currentValue = baselineValue;
                 }
@@ -876,7 +876,7 @@ class BrushTool : NodeSelect {
         if (!(igGetIO().KeyAlt))
             currentBrush.draw(impl.mousePos, impl.transform);
 
-//        drawDifferenceDiagnostics(impl);
+//        dbgDrawDifferenceDiagnostics(impl);
     }
 
 }
@@ -895,7 +895,7 @@ class ToolInfoImpl(T: BrushTool) : ToolInfoBase!(T) {
         igPushStyleVar(ImGuiStyleVar.WindowPadding, ImVec2(4, 4));
         auto brushTool = cast(BrushTool)(editors.length == 0 ? null: editors.values()[0].getTool());
             igBeginGroup();
-                if (incButtonColored("Drag", ImVec2(0, 0), (brushTool !is null && !brushTool.getFlow())? colorUndefined : ImVec4(0.6, 0.6, 0.6, 1))) { // path definition
+                if (incButtonColored("", ImVec2(0, 0), (brushTool !is null && !brushTool.getFlow())? colorUndefined : ImVec4(0.6, 0.6, 0.6, 1))) { // path definition
                     foreach (e; editors) {
                         auto bt = cast(BrushTool)(e.getTool());
                         if (bt)
@@ -905,7 +905,7 @@ class ToolInfoImpl(T: BrushTool) : ToolInfoBase!(T) {
                 incTooltip(_("Drag mode"));
 
                 igSameLine(0, 0);
-                if (incButtonColored("Flow", ImVec2(0, 0), (brushTool !is null && brushTool.getFlow())? colorUndefined : ImVec4(0.6, 0.6, 0.6, 1))) { // path definition
+                if (incButtonColored("", ImVec2(0, 0), (brushTool !is null && brushTool.getFlow())? colorUndefined : ImVec4(0.6, 0.6, 0.6, 1))) { // path definition
                     foreach (e; editors) {
                         auto bt = cast(BrushTool)(e.getTool());
                         if (bt)
@@ -936,21 +936,21 @@ class ToolInfoImpl(T: BrushTool) : ToolInfoBase!(T) {
             igEndGroup();
         igPopStyleVar(2);
 
+        igSameLine(0,4);
         drawTeacherTargetOption(brushTool);
         return false;
     }
     override VertexToolMode mode() { return VertexToolMode.Brush; };
-    override string icon() { return "B";}
+    override string icon() { return "";}
     override string description() { return _("Brush Tool");}
 }
 
 private void drawTeacherTargetOption(BrushTool brushTool) {
     if (brushTool is null) return;
 
-    igSpacing();
-    incText(_("Teacher Part"));
     Part teacher = incBrushGetTeacherPart();
 
+    igSameLine(0, 4);
     ImVec2 previewSize = ImVec2(72, 72);
     igPushID("BRUSH_TEACHER_TARGET");
         if (teacher !is null && teacher.textures.length > 0 && teacher.textures[0]) {
@@ -959,8 +959,8 @@ private void drawTeacherTargetOption(BrushTool brushTool) {
             ImVec4 bg = *igGetStyleColorVec4(ImGuiCol.ChildBg);
             bg.w = 0.15f;
             igPushStyleColor(ImGuiCol.ChildBg, bg);
-            igBeginChild("TeacherDropPlaceholder", previewSize, true, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse | ImGuiWindowFlags.AlwaysUseWindowPadding);
-                incText(_("Drop Part Here"));
+            igBeginChild("Teacher Part", previewSize, true, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse | ImGuiWindowFlags.AlwaysUseWindowPadding);
+                incText(_("Teacher Part"));
             igEndChild();
             igPopStyleColor();
         }
@@ -977,22 +977,15 @@ private void drawTeacherTargetOption(BrushTool brushTool) {
             igEndDragDropTarget();
         }
 
+        igSameLine(0, 0);
         if (igBeginPopupContextItem("TeacherTargetContext", ImGuiPopupFlags.MouseButtonRight)) {
+            igSameLine(0, 4);
             if (igMenuItem(__("Clear"))) {
                 incBrushClearTeacherPart();
             }
             igEndPopup();
         }
 
-        igSpacing();
-        if (teacher !is null) {
-            incText(teacher.name);
-            if (igButton(_("Clear Teacher").toStringz, ImVec2(0, 0))) {
-                incBrushClearTeacherPart();
-            }
-        } else {
-            incText(_("None"));
-        }
     igPopID();
 }
 

--- a/source/nijigenerate/viewport/common/mesheditor/tools/brush.d
+++ b/source/nijigenerate/viewport/common/mesheditor/tools/brush.d
@@ -10,21 +10,46 @@ import nijigenerate.viewport.base;
 import nijigenerate.viewport.common;
 import nijigenerate.viewport.common.mesh;
 import nijigenerate.viewport.common.spline;
+import nijigenerate.viewport.common.mesheditor.brushstate;
 import nijigenerate.core.input;
 import nijigenerate.core.actionstack;
 import nijigenerate.actions;
 import nijigenerate.ext;
 import nijigenerate.widgets;
+import nijigenerate.widgets.texture;
 import nijigenerate;
 import nijilive;
 import nijilive.core.dbg;
+import nijilive.core.diff_collect : DifferenceEvaluationRegion;
+import nijilive.core : inGetDifferenceAggregationRegion;
 import bindbc.opengl;
 import bindbc.imgui;
 import std.algorithm.mutation;
 import std.algorithm.searching;
 //import std.stdio;
 import std.string;
-import std.range;
+import std.math : floor, ceil, isFinite, fabs;
+import std.algorithm : clamp;
+import std.array : array;
+import std.format : format;
+import std.range : iota;
+import std.stdio : stderr, writefln;
+import nijigenerate.core.dpi : incGetUIScale;
+import nijigenerate.core.window :
+    incDifferenceAggregationResult,
+    incDifferenceAggregationResultValid,
+    incDifferenceAggregationResultSerial;
+
+enum TileColumns = 16;
+enum TileCount = TileColumns * TileColumns;
+enum OptimizationSampleCount = 101;
+enum float OptimizationMoveEpsilon = 1e-4f;
+
+private struct StrokeVertex {
+    MeshVertex* vertex;
+    vec2 startPos;
+    vec2 endPos;
+}
 
 private {
     Brush _currentBrush;
@@ -46,21 +71,91 @@ class BrushTool : NodeSelect {
     vec2 initPos;
     int axisDirection; // 0: none, 1: lock to horizontal move only, 2: lock to vertical move only
 
+    vec2[ulong] dragStartPositions;
+    ulong[] draggedVertices;
+    bool optimizePending;
+
+    StrokeVertex[] strokeVertices;
+    float[] optimizationSamples;
+    bool waitingForResult;
+    float pendingSampleParameter;
+    ulong lastResultSerial;
+    double[] bestScores;
+    float[] bestParameters;
+    DifferenceEvaluationRegion activeRegion;
+    bool activeRegionValid;
+    int activeViewportWidth;
+    int activeViewportHeight;
+    size_t currentSampleIndex;
+    bool anyVertexAdjusted;
+    double[] baselineTileValues;
+    double baselineGlobalScore = double.infinity;
+    bool baselineValid;
+
     bool getFlow() { return flow; }
     void setFlow(bool value) { flow = value; }
 
+    void resetDragTracking() {
+        dragStartPositions = typeof(dragStartPositions).init;
+        draggedVertices.length = 0;
+        strokeVertices.length = 0;
+        optimizationSamples.length = 0;
+        waitingForResult = false;
+        pendingSampleParameter = 1.0f;
+        lastResultSerial = incDifferenceAggregationResultSerial;
+        bestScores.length = 0;
+        bestParameters.length = 0;
+        activeRegionValid = false;
+        activeViewportWidth = 0;
+        activeViewportHeight = 0;
+        activeRegion = DifferenceEvaluationRegion.init;
+        currentSampleIndex = 0;
+        anyVertexAdjusted = false;
+        optimizePending = false;
+        baselineTileValues.length = 0;
+        baselineGlobalScore = double.infinity;
+        baselineValid = false;
+    }
+
+    void captureBaselineDifference() {
+        baselineTileValues.length = TileCount;
+        if (incDifferenceAggregationResultValid) {
+            foreach (i; 0 .. TileCount) {
+                double count = incDifferenceAggregationResult.tileCounts[i];
+                double value = count > 0 ? incDifferenceAggregationResult.tileTotals[i] / count : double.infinity;
+                baselineTileValues[i] = value;
+            }
+            baselineGlobalScore = computeGlobalDifferenceMetric();
+        } else {
+            foreach (i; 0 .. TileCount) {
+                baselineTileValues[i] = 0.0;
+            }
+            baselineGlobalScore = 0.0;
+        }
+        baselineValid = true;
+    }
+
     override bool onDragStart(vec2 mousePos, IncMeshEditorOne impl) {
-        if (isDragging) {
+        bool started = super.onDragStart(mousePos, impl);
+        if (started) {
+            resetDragTracking();
+            captureBaselineDifference();
             if (!flow)
                 weights = impl.getVerticesInBrush(impl.mousePos, currentBrush);
             initPos = impl.mousePos;
             axisDirection = 0;
         }
-        return super.onDragStart(mousePos, impl);
+        return started;
     }
 
     override bool onDragEnd(vec2 mousePos, IncMeshEditorOne impl) {
-        return super.onDragEnd(mousePos, impl);
+        bool result = super.onDragEnd(mousePos, impl);
+        if (draggedVertices.length > 0 && incBrushHasTeacherPart()) {
+            initializeStrokeOptimization(impl);
+        } else {
+            resetDragTracking();
+        }
+        return result;
     }
 
     override bool onDragUpdate(vec2 mousePos, IncMeshEditorOne impl) {
@@ -214,6 +309,7 @@ class BrushTool : NodeSelect {
                 if (v is null)
                     continue;
                 if (weight > 0) {
+                    registerDraggedVertex(idx, v);
                     impl.moveMeshVertex(v, v.position + diffPos * weight);
                     impl.markActionDirty();
                 }
@@ -224,8 +320,427 @@ class BrushTool : NodeSelect {
         } else if (isDragging)
             onDragUpdate(impl.mousePos, impl);
 
+        bool optimizationChanged = applyOptimizationIfReady(impl);
+
+        if (optimizationChanged) {
+            changed = true;
+        }
+
         if (changed) impl.refreshMesh();
         return changed;
+    }
+
+    void registerDraggedVertex(ulong index, MeshVertex* vertex) {
+        if (index !in dragStartPositions) {
+            dragStartPositions[index] = vertex.position;
+            draggedVertices ~= index;
+        }
+    }
+
+    void initializeStrokeOptimization(IncMeshEditorOne impl) {
+        strokeVertices.length = 0;
+        foreach (idx; draggedVertices) {
+            MeshVertex* vertex = impl.getVerticesByIndex([idx])[0];
+            if (vertex is null)
+                continue;
+
+            vec2* startPtr = idx in dragStartPositions;
+            vec2 startPos = startPtr ? *startPtr : vertex.position;
+            vec2 endPos = vertex.position;
+            if ((endPos - startPos).length <= OptimizationMoveEpsilon) {
+                continue;
+            }
+
+            strokeVertices ~= StrokeVertex(vertex, startPos, endPos);
+        }
+
+        optimizationSamples.length = 0;
+        waitingForResult = false;
+        pendingSampleParameter = 1.0f;
+        lastResultSerial = incDifferenceAggregationResultSerial;
+        activeRegionValid = false;
+
+        if (strokeVertices.length == 0) {
+            optimizePending = false;
+            resetDragTracking();
+            return;
+        }
+
+        bestScores.length = strokeVertices.length;
+        bestParameters.length = strokeVertices.length;
+        foreach (i; 0 .. strokeVertices.length) {
+            bestScores[i] = double.infinity;
+            bestParameters[i] = 1.0f;
+        }
+
+        int viewportWidth, viewportHeight;
+        inGetViewport(viewportWidth, viewportHeight);
+        activeRegion = inGetDifferenceAggregationRegion();
+        activeRegionValid = activeRegion.width > 0 && activeRegion.height > 0;
+        activeViewportWidth = viewportWidth;
+        activeViewportHeight = viewportHeight;
+
+        optimizationSamples.length = OptimizationSampleCount;
+        foreach (i; 0 .. OptimizationSampleCount) {
+            optimizationSamples[i] = OptimizationSampleCount <= 1 ? 1.0f : cast(float)i / cast(float)(OptimizationSampleCount - 1);
+        }
+
+        currentSampleIndex = 0;
+        waitingForResult = false;
+        anyVertexAdjusted = false;
+        optimizePending = true;
+    }
+
+    void setStrokeParameter(IncMeshEditorOne impl, float parameter) {
+        foreach (ref data; strokeVertices) {
+            vec2 candidate = data.startPos * (1 - parameter) + data.endPos * parameter;
+            impl.moveMeshVertex(data.vertex, candidate);
+        }
+    }
+
+    void updateScoresForSample(IncMeshEditorOne impl) {
+        double globalScore = computeGlobalDifferenceMetric();
+
+        double[TileCount] tileValues;
+        bool anyFinite = false;
+        if (activeRegionValid) {
+            foreach (i; 0 .. TileCount) {
+                double count = incDifferenceAggregationResult.tileCounts[i];
+                if (count > 0) {
+                    tileValues[i] = incDifferenceAggregationResult.tileTotals[i] / count;
+                    anyFinite = true;
+                } else {
+                    tileValues[i] = double.infinity;
+                }
+            }
+
+            static size_t tileDebugCounter;
+            if (tileDebugCounter < 10) {
+                double minValue = double.infinity;
+                double maxValue = -double.infinity;
+                foreach (value; tileValues) {
+                    if (isFinite(value)) {
+                        if (value < minValue) minValue = value;
+                        if (value > maxValue) maxValue = value;
+                    }
+                }
+                stderr.writefln("[diff] brush sample #%s global=%.6f min=%.6f max=%.6f", tileDebugCounter, globalScore, minValue, maxValue);
+                foreach (int ty; 0 .. TileColumns) {
+                    string line;
+                    foreach (int tx; 0 .. TileColumns) {
+                        size_t idx = cast(size_t)ty * TileColumns + tx;
+                        double value = tileValues[idx];
+                        line ~= isFinite(value) ? format(" %8.5f", value) : "    nan";
+                    }
+                    stderr.writefln("[diff] brush row %02d:%s", ty, line);
+                }
+                tileDebugCounter++;
+            }
+        }
+
+        mat4 combinedMatrix = computeCombinedMatrix(impl);
+        auto camera = inGetCamera();
+        mat4 cameraMatrix = camera.matrix();
+
+        foreach (i, ref data; strokeVertices) {
+            vec2 position = data.vertex.position;
+            double score = double.infinity;
+            if (activeRegionValid && anyFinite) {
+                score = sampleDifferenceAt(position, combinedMatrix, cameraMatrix, tileValues);
+            }
+            if (!isFinite(score)) {
+                score = globalScore;
+            }
+            if (!isFinite(score))
+                continue;
+
+            if (score <= bestScores[i]) {
+                bestScores[i] = score;
+                bestParameters[i] = pendingSampleParameter;
+            }
+        }
+    }
+
+    void applyBestParameters(IncMeshEditorOne impl) {
+        bool adjusted = false;
+        foreach (i, ref data; strokeVertices) {
+            float parameter = (i < bestParameters.length) ? clamp(bestParameters[i], 0.0f, 1.0f) : 1.0f;
+            vec2 candidate = data.startPos * (1 - parameter) + data.endPos * parameter;
+            if ((candidate - data.endPos).length > OptimizationMoveEpsilon) {
+                adjusted = true;
+            }
+            impl.moveMeshVertex(data.vertex, candidate);
+        }
+
+        anyVertexAdjusted = adjusted;
+    }
+
+    mat4 computeCombinedMatrix(IncMeshEditorOne impl) {
+        mat4 baseMatrix = impl.transform;
+        Node targetNode = impl.getTarget();
+        if (targetNode is null) {
+            return baseMatrix;
+        }
+
+        mat4 puppetMatrix = mat4.identity;
+        if (auto puppet = targetNode.puppet) {
+            puppetMatrix = puppet.transform.matrix;
+            if (auto part = cast(Part)targetNode) {
+                if (part.ignorePuppet) {
+                    puppetMatrix = mat4.identity;
+                }
+            }
+        }
+
+        return puppetMatrix * baseMatrix;
+    }
+
+    double sampleDifferenceAt(vec2 position, mat4 combinedMatrix, mat4 cameraMatrix, ref double[TileCount] tileValues) const {
+        if (!activeRegionValid || activeViewportWidth <= 0 || activeViewportHeight <= 0) {
+            return double.infinity;
+        }
+
+        vec4 clip = cameraMatrix * (combinedMatrix * vec4(position.x, position.y, 0, 1));
+        if (fabs(clip.w) < 1e-6f) {
+            return double.infinity;
+        }
+
+        double ndcX = clip.x / clip.w;
+        double ndcY = clip.y / clip.w;
+        double px = (ndcX * 0.5 + 0.5) * activeViewportWidth;
+        double py = (ndcY * 0.5 + 0.5) * activeViewportHeight;
+
+        double localX = px - activeRegion.x;
+        double localY = py - activeRegion.y;
+
+        if (localX < 0 || localY < 0 || localX >= activeRegion.width || localY >= activeRegion.height) {
+            return double.infinity;
+        }
+
+        double invWidth = activeRegion.width > 0 ? cast(double)TileColumns / activeRegion.width : 0;
+        double invHeight = activeRegion.height > 0 ? cast(double)TileColumns / activeRegion.height : 0;
+
+        double gridX = localX * invWidth;
+        double gridY = localY * invHeight;
+
+        int x0 = cast(int)floor(gridX);
+        int y0 = cast(int)floor(gridY);
+        x0 = clamp(x0, 0, TileColumns - 1);
+        y0 = clamp(y0, 0, TileColumns - 1);
+
+        int x1 = x0 < TileColumns - 1 ? x0 + 1 : x0;
+        int y1 = y0 < TileColumns - 1 ? y0 + 1 : y0;
+
+        double tx = gridX - x0;
+        double ty = gridY - y0;
+        if (x1 == x0) tx = 0;
+        if (y1 == y0) ty = 0;
+
+        double accum = 0;
+        double weightSum = 0;
+
+        auto accumulate = (int ix, int iy, double weight) {
+            if (weight <= 0) return;
+            size_t idx = cast(size_t)iy * TileColumns + ix;
+            double value = tileValues[idx];
+            if (!isFinite(value)) return;
+            accum += value * weight;
+            weightSum += weight;
+        };
+
+        accumulate(x0, y0, (1 - tx) * (1 - ty));
+        accumulate(x1, y0, tx * (1 - ty));
+        accumulate(x0, y1, (1 - tx) * ty);
+        accumulate(x1, y1, tx * ty);
+
+        if (weightSum > 0) {
+            return accum / weightSum;
+        }
+        return double.infinity;
+    }
+
+    double computeGlobalDifferenceMetric() const {
+        if (!incDifferenceAggregationResultValid)
+            return double.infinity;
+
+        if (incDifferenceAggregationResult.alpha > 0) {
+            return incDifferenceAggregationResult.total / incDifferenceAggregationResult.alpha;
+        }
+        double sumTotals = 0;
+        double sumWeights = 0;
+        foreach (value; incDifferenceAggregationResult.tileTotals) {
+            sumTotals += value;
+        }
+        foreach (value; incDifferenceAggregationResult.tileCounts) {
+            sumWeights += value;
+        }
+
+        if (sumWeights > 0) {
+            return sumTotals / sumWeights;
+        }
+        return double.infinity;
+    }
+
+    void finalizeOptimization(IncMeshEditorOne impl) {
+        applyBestParameters(impl);
+        impl.refreshMesh();
+        if (anyVertexAdjusted) {
+            impl.markActionDirty();
+        }
+        resetDragTracking();
+    }
+
+    bool applyOptimizationIfReady(IncMeshEditorOne impl) {
+        if (!optimizePending)
+            return false;
+
+        if (!incBrushHasTeacherPart() || strokeVertices.length == 0) {
+            resetDragTracking();
+            return false;
+        }
+
+        if (!baselineValid && incDifferenceAggregationResultValid) {
+            captureBaselineDifference();
+        }
+
+        if (!activeRegionValid) {
+            int viewportWidth, viewportHeight;
+            inGetViewport(viewportWidth, viewportHeight);
+            activeRegion = inGetDifferenceAggregationRegion();
+            activeRegionValid = activeRegion.width > 0 && activeRegion.height > 0;
+            if (activeRegionValid) {
+                activeViewportWidth = viewportWidth;
+                activeViewportHeight = viewportHeight;
+            }
+        }
+
+        if (waitingForResult) {
+            if (incDifferenceAggregationResultValid && incDifferenceAggregationResultSerial != lastResultSerial) {
+                lastResultSerial = incDifferenceAggregationResultSerial;
+                activeRegion = inGetDifferenceAggregationRegion();
+                activeRegionValid = activeRegion.width > 0 && activeRegion.height > 0;
+                updateScoresForSample(impl);
+                waitingForResult = false;
+            }
+            return false;
+        }
+
+        if (currentSampleIndex >= optimizationSamples.length) {
+            finalizeOptimization(impl);
+            return true;
+        }
+
+        pendingSampleParameter = optimizationSamples[currentSampleIndex++];
+        setStrokeParameter(impl, pendingSampleParameter);
+        lastResultSerial = incDifferenceAggregationResultSerial;
+        impl.refreshMesh();
+        waitingForResult = true;
+        return true;
+    }
+
+    void drawDifferenceDiagnostics(IncMeshEditorOne impl) {
+        if (!baselineValid && incDifferenceAggregationResultValid) {
+            captureBaselineDifference();
+        }
+
+        auto region = inGetDifferenceAggregationRegion();
+        int viewportPixelWidth;
+        int viewportPixelHeight;
+        inGetViewport(viewportPixelWidth, viewportPixelHeight);
+        if (region.width <= 0 || region.height <= 0) {
+            region = DifferenceEvaluationRegion(0, 0, viewportPixelWidth, viewportPixelHeight);
+        }
+
+        if (baselineTileValues.length < TileCount)
+            return;
+
+        if (activeViewportWidth > 0)
+            viewportPixelWidth = activeViewportWidth;
+        else if (viewportPixelWidth <= 0)
+            viewportPixelWidth = region.width;
+
+        if (activeViewportHeight > 0)
+            viewportPixelHeight = activeViewportHeight;
+        else if (viewportPixelHeight <= 0)
+            viewportPixelHeight = region.height;
+
+        if (viewportPixelWidth <= 0 || viewportPixelHeight <= 0)
+            return;
+
+        float tilePixelWidth = cast(float)region.width / TileColumns;
+        float tilePixelHeight = cast(float)region.height / TileColumns;
+        if (tilePixelWidth <= 0 || tilePixelHeight <= 0)
+            return;
+
+        auto camera = inGetCamera();
+        mat4 viewProj = camera.matrix();
+        mat4 invViewProj = viewProj.inverse();
+
+        double currentGlobal = incDifferenceAggregationResultValid ? computeGlobalDifferenceMetric() : baselineGlobalScore;
+        const double epsilon = 1e-6;
+        vec4 improveColor = vec4(0, 1, 0, 0.8f);
+        vec4 worsenColor = vec4(1, 0, 0, 0.8f);
+        vec4 unchangedColor = vec4(0.6f, 0.6f, 0.6f, 0.8f);
+
+        vec3[] improvedPoints;
+        vec3[] worsenedPoints;
+        vec3[] unchangedPoints;
+
+        foreach (int ty; 0 .. TileColumns) {
+            foreach (int tx; 0 .. TileColumns) {
+                size_t idx = cast(size_t)ty * TileColumns + tx;
+                double baselineValue = idx < baselineTileValues.length ? baselineTileValues[idx] : baselineGlobalScore;
+                if (!isFinite(baselineValue)) baselineValue = baselineGlobalScore;
+
+                double currentValue;
+                if (incDifferenceAggregationResultValid) {
+                    double count = incDifferenceAggregationResult.tileCounts[idx];
+                    currentValue = count > 0 ? incDifferenceAggregationResult.tileTotals[idx] / count : currentGlobal;
+                } else {
+                    currentValue = baselineValue;
+                }
+
+                if (!isFinite(currentValue)) currentValue = currentGlobal;
+                if (!isFinite(baselineValue)) baselineValue = baselineGlobalScore;
+                if (!isFinite(currentValue)) currentValue = 0;
+                if (!isFinite(baselineValue)) baselineValue = 0;
+
+                double delta = currentValue - baselineValue;
+
+                float centerPixelX = region.x + (tx + 0.5f) * tilePixelWidth;
+                float centerPixelY = region.y + (ty + 0.5f) * tilePixelHeight;
+                float clipX = (centerPixelX / viewportPixelWidth) * 2.0f - 1.0f;
+                float clipY = (centerPixelY / viewportPixelHeight) * 2.0f - 1.0f;
+                vec4 clipPos = vec4(clipX, clipY, 0, 1);
+                vec4 worldPos = invViewProj * clipPos;
+                if (worldPos.w != 0) {
+                    worldPos /= worldPos.w;
+                }
+                vec3 worldCenter = worldPos.xyz;
+
+                if (delta < -epsilon) {
+                    improvedPoints ~= worldCenter;
+                } else if (delta > epsilon) {
+                    worsenedPoints ~= worldCenter;
+                } else {
+                    unchangedPoints ~= worldCenter;
+                }
+            }
+        }
+
+        inDbgPointsSize(10);
+        if (improvedPoints.length) {
+            inDbgSetBuffer(improvedPoints);
+            inDbgDrawPoints(improveColor);
+        }
+        if (worsenedPoints.length) {
+            inDbgSetBuffer(worsenedPoints);
+            inDbgDrawPoints(worsenColor);
+        }
+        if (unchangedPoints.length) {
+            inDbgSetBuffer(unchangedPoints);
+            inDbgDrawPoints(unchangedColor);
+        }
     }
 
     override
@@ -233,6 +748,8 @@ class BrushTool : NodeSelect {
         super.draw(camera, impl);
         if (!(igGetIO().KeyAlt))
             currentBrush.draw(impl.mousePos, impl.transform);
+
+        drawDifferenceDiagnostics(impl);
     }
 
 }
@@ -291,9 +808,63 @@ class ToolInfoImpl(T: BrushTool) : ToolInfoBase!(T) {
 
             igEndGroup();
         igPopStyleVar(2);
+
+        drawTeacherTargetOption(brushTool);
         return false;
     }
     override VertexToolMode mode() { return VertexToolMode.Brush; };
     override string icon() { return "";}
     override string description() { return _("Brush Tool");}
+}
+
+private void drawTeacherTargetOption(BrushTool brushTool) {
+    if (brushTool is null) return;
+
+    igSpacing();
+    incText(_("Teacher Part"));
+    Part teacher = incBrushGetTeacherPart();
+
+    ImVec2 previewSize = ImVec2(72, 72);
+    igPushID("BRUSH_TEACHER_TARGET");
+        if (teacher !is null && teacher.textures.length > 0 && teacher.textures[0]) {
+            incTextureSlotUntitled("TeacherPreview", teacher.textures[0], previewSize, 32, ImGuiWindowFlags.None, false);
+        } else {
+            ImVec4 bg = *igGetStyleColorVec4(ImGuiCol.ChildBg);
+            bg.w = 0.15f;
+            igPushStyleColor(ImGuiCol.ChildBg, bg);
+            igBeginChild("TeacherDropPlaceholder", previewSize, true, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse | ImGuiWindowFlags.AlwaysUseWindowPadding);
+                incText(_("Drop Part Here"));
+            igEndChild();
+            igPopStyleColor();
+        }
+
+        if (igBeginDragDropTarget()) {
+            const(ImGuiPayload)* payload = igAcceptDragDropPayload("_PUPPETNTREE");
+            if (payload !is null) {
+                if (Node* nodePtr = cast(Node*)payload.Data) {
+                    if (Part part = cast(Part)(*nodePtr)) {
+                        incBrushSetTeacherPart(part);
+                    }
+                }
+            }
+            igEndDragDropTarget();
+        }
+
+        if (igBeginPopupContextItem("TeacherTargetContext", ImGuiPopupFlags.MouseButtonRight)) {
+            if (igMenuItem(__("Clear"))) {
+                incBrushClearTeacherPart();
+            }
+            igEndPopup();
+        }
+
+        igSpacing();
+        if (teacher !is null) {
+            incText(teacher.name);
+            if (igButton(_("Clear Teacher").toStringz, ImVec2(0, 0))) {
+                incBrushClearTeacherPart();
+            }
+        } else {
+            incText(_("None"));
+        }
+    igPopID();
 }

--- a/source/nijigenerate/widgets/mainmenu.d
+++ b/source/nijigenerate/widgets/mainmenu.d
@@ -350,10 +350,20 @@ void incMainMenu() {
             string statsText = fpsText;
             if (incDifferenceAggregationDebugEnabled) {
                 string diffValue;
-                if (incDifferenceAggregationResultValid && incDifferenceAggregationResult.sampleCount > 0) {
-                    diffValue = "%.3f".format(
-                        incDifferenceAggregationResult.total / cast(double)incDifferenceAggregationResult.sampleCount
-                    );
+                if (incDifferenceAggregationResultValid) {
+                    double sumTotals = 0;
+                    double sumWeights = 0;
+                    foreach (i; 0 .. incDifferenceAggregationResult.tileTotals.length) {
+                        sumTotals += incDifferenceAggregationResult.tileTotals[i];
+                        sumWeights += incDifferenceAggregationResult.tileCounts[i];
+                    }
+                    if (sumWeights > 0) {
+                        diffValue = "%.3f".format(sumTotals / sumWeights);
+                    } else if (incDifferenceAggregationResult.alpha > 0) {
+                        diffValue = "%.3f".format(incDifferenceAggregationResult.total / incDifferenceAggregationResult.alpha);
+                    } else {
+                        diffValue = "--";
+                    }
                 } else {
                     diffValue = "--";
                 }

--- a/source/nijigenerate/widgets/mainmenu.d
+++ b/source/nijigenerate/widgets/mainmenu.d
@@ -338,17 +338,17 @@ void incMainMenu() {
             string statsText = fpsText;
             if (teacherDiffActive) {
                 string diffValue;
-                if (incDifferenceAggregationResultValid) {
+                if (ngDifferenceAggregationResultValid) {
                     double sumTotals = 0;
                     double sumWeights = 0;
-                    foreach (i; 0 .. incDifferenceAggregationResult.tileTotals.length) {
-                        sumTotals += incDifferenceAggregationResult.tileTotals[i];
-                        sumWeights += incDifferenceAggregationResult.tileCounts[i];
+                    foreach (i; 0 .. ngDifferenceAggregationResult.tileTotals.length) {
+                        sumTotals += ngDifferenceAggregationResult.tileTotals[i];
+                        sumWeights += ngDifferenceAggregationResult.tileCounts[i];
                     }
                     if (sumWeights > 0) {
                         diffValue = "%.3f".format(sumTotals / sumWeights);
-                    } else if (incDifferenceAggregationResult.alpha > 0) {
-                        diffValue = "%.3f".format(incDifferenceAggregationResult.total / incDifferenceAggregationResult.alpha);
+                    } else if (ngDifferenceAggregationResult.alpha > 0) {
+                        diffValue = "%.3f".format(ngDifferenceAggregationResult.total / ngDifferenceAggregationResult.alpha);
                     } else {
                         diffValue = "--";
                     }


### PR DESCRIPTION
Brush option has new "Teachrer" part option.
If you drop any `Part` object to that teacher part, brush started to use it as a "teacher" part.
Brush automatically fit the deformation to minimize the difference of current image and target "teacher" image.

If you prepare any texture image which can be the teacher of the deformation, you can semi-automatically adjust the deformation for the teacher image.