### PR TITLE
Improve OneTimeDeform apply behavior and edit scope handling

### DIFF
--- a/source/nijigenerate/core/actionstack.d
+++ b/source/nijigenerate/core/actionstack.d
@@ -10,6 +10,13 @@ import nijigenerate.core.settings;
 import nijigenerate.actions;
 import nijilive;
 
+enum ActionStackScopeUnit {
+    Manual,
+    VertexEdit,
+    DepthEdit,
+    OneTimeDeform
+}
+
 private {
     Action[][] actions;
     size_t currentLevel = 0;
@@ -20,6 +27,56 @@ private {
     // Tracks the action index last marked as "saved" per level
     size_t[] savedIndex;
     size_t maxUndoHistory;
+    ActionStackScope[ActionStackScopeUnit] activeScopes;
+    void function(ActionStackScopeUnit)[ActionStackScopeUnit] scopeCloseHandlers;
+}
+
+final class ActionStackScope {
+private:
+    bool active;
+    size_t level;
+    ActionStackScopeUnit unit;
+
+public:
+    this(ActionStackScopeUnit unit = ActionStackScopeUnit.Manual) {
+        this.unit = unit;
+        incActionPushStack();
+        level = currentLevel;
+        active = true;
+    }
+
+    void close() {
+        if (!active) return;
+
+        auto closeUnit = unit;
+        if (unit != ActionStackScopeUnit.Manual) {
+            ActionStackScopeUnit[] staleUnits;
+            foreach (activeUnit, activeScope; activeScopes) {
+                if (activeScope.level >= level) {
+                    activeScope.active = false;
+                    staleUnits ~= activeUnit;
+                }
+            }
+            foreach (activeUnit; staleUnits)
+                activeScopes.remove(activeUnit);
+        }
+
+        while (currentLevel >= level && currentLevel > 0) {
+            incActionPopStack();
+        }
+        active = false;
+
+        if (auto handler = closeUnit in scopeCloseHandlers)
+            (*handler)(closeUnit);
+    }
+
+    bool isActive() {
+        return active;
+    }
+
+    ~this() {
+        close();
+    }
 }
 
 enum ActionStackClear {
@@ -205,6 +262,9 @@ void incActionSetIndex(size_t index) {
 void incActionClearHistory(ActionStackClear target = ActionStackClear.All) {
     switch (target) {
     case ActionStackClear.All:
+        foreach (activeScope; activeScopes.byValue)
+            activeScope.active = false;
+        activeScopes.clear();
         currentLevel = 0;
         actions.length = currentLevel + 1;
         actionPointer.length = currentLevel + 1;
@@ -219,6 +279,15 @@ void incActionClearHistory(ActionStackClear target = ActionStackClear.All) {
         savedIndex[currentLevel] = 0;
         break;
     case ActionStackClear.CurrentLevel:
+        ActionStackScopeUnit[] staleUnits;
+        foreach (activeUnit, activeScope; activeScopes) {
+            if (activeScope.level >= currentLevel) {
+                activeScope.active = false;
+                staleUnits ~= activeUnit;
+            }
+        }
+        foreach (activeUnit; staleUnits)
+            activeScopes.remove(activeUnit);
         actions[currentLevel].length = 0;
         actionPointer[currentLevel] = 0;
         currentGroup[currentLevel] = null;
@@ -257,6 +326,58 @@ void incActionPushStack() {
     groupCount.length = currentLevel + 1;
     savedIndex.length = currentLevel + 1;
     savedIndex[currentLevel] = 0;
+}
+
+ActionStackScope ngOpenActionStackScope(ActionStackScopeUnit unit = ActionStackScopeUnit.Manual) {
+    if (unit != ActionStackScopeUnit.Manual) {
+        if (auto found = unit in activeScopes) {
+            if ((*found).isActive())
+                return *found;
+            activeScopes.remove(unit);
+        }
+    }
+
+    auto created = new ActionStackScope(unit);
+    if (unit != ActionStackScopeUnit.Manual)
+        activeScopes[unit] = created;
+    return created;
+}
+
+void ngCloseActionStackScope(ActionStackScopeUnit unit) {
+    if (auto found = unit in activeScopes)
+        (*found).close();
+}
+
+void ngRegisterActionStackScopeCloseHandler(ActionStackScopeUnit unit, void function(ActionStackScopeUnit) handler) {
+    scopeCloseHandlers[unit] = handler;
+}
+
+void ngGuardActionStackScopes(scope const(ActionStackScopeUnit)[] allowedUnits = null) {
+    bool isAllowed(ActionStackScopeUnit unit) {
+        foreach (allowed; allowedUnits) {
+            if (allowed == unit)
+                return true;
+        }
+        return false;
+    }
+
+    ActionStackScope[] scopesToClose;
+    foreach (unit, activeScope; activeScopes) {
+        if (!isAllowed(unit))
+            scopesToClose ~= activeScope;
+    }
+    foreach (activeScope; scopesToClose)
+        activeScope.close();
+}
+
+bool ngActionStackScopeActive(ActionStackScopeUnit unit) {
+    if (auto found = unit in activeScopes)
+        return (*found).isActive();
+    return false;
+}
+
+size_t ngActionStackLevel() {
+    return currentLevel;
 }
 
 void incActionPopStack() {

--- a/source/nijigenerate/project.d
+++ b/source/nijigenerate/project.d
@@ -83,6 +83,7 @@ package(nijigenerate) {
 
     void function(Puppet)[] loadCallbacks;
     void function(Puppet)[] saveCallbacks;
+    void function(Puppet)[] postSaveCallbacks;
 }
 
 
@@ -92,6 +93,10 @@ void incRegisterLoadFunc(void function(Puppet) func) {
 
 void incRegisterSaveFunc(void function(Puppet) func) {
     saveCallbacks ~= func;
+}
+
+void ngRegisterPostSaveFunc(void function(Puppet) func) {
+    postSaveCallbacks ~= func;
 }
 
 void ngRegisterProjectCallback(void function(Project) func) {
@@ -361,6 +366,10 @@ void incSaveProject(string path, string autosaveStamp = "") {
 
         // Remember to populate texture slots otherwise things will break real bad!
         incActivePuppet().populateTextureSlots();
+        scope(exit) {
+            foreach (func; postSaveCallbacks)
+                func(incActivePuppet());
+        }
         foreach (func; saveCallbacks)
             func(incActivePuppet());
 
@@ -774,6 +783,21 @@ ModelEditSubMode ngModelEditSubMode() {
 void incSetEditMode(EditMode editMode, bool unselect = true) {
     if (activeProject) activeProject.EditModeChanging.emit(editMode_);
 //    incViewportWithdrawMode(editMode_);
+
+    final switch (editMode) {
+    case EditMode.VertexEdit:
+        ngGuardActionStackScopes([ActionStackScopeUnit.VertexEdit]);
+        break;
+    case EditMode.DepthEdit:
+        ngGuardActionStackScopes([ActionStackScopeUnit.DepthEdit]);
+        break;
+    case EditMode.ModelEdit:
+    case EditMode.AnimEdit:
+    case EditMode.ModelTest:
+    case EditMode.ALL:
+        ngGuardActionStackScopes();
+        break;
+    }
 
     if (armedParam) {
         armedParam.value = armedParam.getClosestKeypointValue(armedParam.value);

--- a/source/nijigenerate/viewport/common/mesheditor/operations/base.d
+++ b/source/nijigenerate/viewport/common/mesheditor/operations/base.d
@@ -262,6 +262,7 @@ public:
 
     abstract void setToolMode(VertexToolMode toolMode);
     abstract void finalizeToolMode();
+    abstract void abortToolMode();
 
     bool previewingTriangulation() {
          return previewTriangulate && toolMode == VertexToolMode.Points;

--- a/source/nijigenerate/viewport/common/mesheditor/operations/impl.d
+++ b/source/nijigenerate/viewport/common/mesheditor/operations/impl.d
@@ -202,9 +202,10 @@ void resize(T:MeshVertex*)(ref T[] array, ulong size) {
     if (size <= array.length) {
         array.length = size;
     } else {
-        while (size != 0) {
+        auto missing = size - array.length;
+        while (missing != 0) {
             array ~= new MeshVertex;
-            size --;
+            missing--;
         }
     }
 }

--- a/source/nijigenerate/viewport/common/mesheditor/operations/impl.d
+++ b/source/nijigenerate/viewport/common/mesheditor/operations/impl.d
@@ -108,6 +108,7 @@ public:
         if (this.toolMode == toolMode) return;
 
         if (toolMode in tools) {
+            abortToolMode();
             this.toolMode = toolMode;
             tools[toolMode].setToolMode(toolMode, this);
         }
@@ -116,9 +117,14 @@ public:
     override
     void finalizeToolMode() {
         if (toolMode in tools) {
-            import std.stdio;
-            writefln("finalize %s, %s", toolMode, target.name);
             tools[toolMode].finalizeToolMode(this);
+        }
+    }
+
+    override
+    void abortToolMode() {
+        if (toolMode in tools) {
+            tools[toolMode].abortToolMode(this);
         }
     }
 

--- a/source/nijigenerate/viewport/common/mesheditor/package.d
+++ b/source/nijigenerate/viewport/common/mesheditor/package.d
@@ -67,8 +67,10 @@ public:
     abstract void setTargets(Node[] targets);
 
     void removeTarget(Node target) {
-        if (target in editors)
+        if (target in editors) {
+            editors[target].abortToolMode();
             editors.remove(target);
+        }
     }
 
     Node[] getTargets() {
@@ -78,6 +80,12 @@ public:
     void refreshMesh() {
         foreach (drawing, editor; editors) {
             editor.refreshMesh();
+        }
+    }
+
+    void abortActiveTools() {
+        foreach (editor; editors.byValue) {
+            editor.abortToolMode();
         }
     }
 

--- a/source/nijigenerate/viewport/common/mesheditor/tools/base.d
+++ b/source/nijigenerate/viewport/common/mesheditor/tools/base.d
@@ -27,6 +27,7 @@ class Tool {
     abstract void setToolMode(VertexToolMode toolMode, IncMeshEditorOne impl);
     abstract void draw(Camera camera, IncMeshEditorOne impl);
     abstract void finalizeToolMode(IncMeshEditorOne impl);
+    void abortToolMode(IncMeshEditorOne impl) { }
 
     MeshEditorAction!DeformationAction editorAction(Node target, DeformationAction action) {
         return new MeshEditorAction!(DeformationAction)(target, action);

--- a/source/nijigenerate/viewport/common/mesheditor/tools/enums.d
+++ b/source/nijigenerate/viewport/common/mesheditor/tools/enums.d
@@ -7,7 +7,7 @@ enum VertexToolMode {
     Grid,
     Brush,
     BezierDeform,
-    AltMeshGroup,
+    AltGridDeform,
     AltBezierDeform,
     LassoSelection,
     EdgeCutter,

--- a/source/nijigenerate/viewport/common/mesheditor/tools/grid.d
+++ b/source/nijigenerate/viewport/common/mesheditor/tools/grid.d
@@ -11,6 +11,7 @@ import nijigenerate.viewport.common;
 import nijigenerate.viewport.common.mesh;
 import nijigenerate.core.input;
 import nijigenerate.core.actionstack;
+import nijigenerate.core.math.mesh : applyMeshToTarget;
 import nijigenerate.actions;
 import nijigenerate.ext;
 import nijigenerate.widgets;
@@ -20,7 +21,7 @@ import nijigenerate.core.dbg;
 import nijilive.core.nodes.deformer.grid : GridDeformer;
 import bindbc.opengl;
 import bindbc.imgui;
-//import std.stdio;
+import std.stdio : writefln;
 import std.array;
 import std.algorithm.searching: countUntil;
 import std.algorithm.mutation;
@@ -29,11 +30,20 @@ import std.algorithm.searching : all;
 
 class GridTool : NodeSelect {
 private:
+    void oneTimeGridLog(Args...)(string fmt, Args args) {
+        writefln("[OneTimeDeform/Grid] " ~ fmt, args);
+    }
+
     struct VirtualMeshContext {
         IncMesh mesh;
     }
 
     VirtualMeshContext[IncMeshEditorOneDeformable] deformableMeshes;
+
+    IncMesh createEmptyMesh() {
+        MeshData meshData;
+        return new IncMesh(meshData);
+    }
 
     IncMesh getMesh(IncMeshEditorOne impl, out bool isVirtual) {
         if (auto drawable = cast(IncMeshEditorOneDrawable)impl) {
@@ -62,6 +72,17 @@ private:
 
     public:
 
+    void resetVirtualMeshAsEmpty(IncMeshEditorOne impl) {
+        if (auto deformable = cast(IncMeshEditorOneDeformable)impl) {
+            auto mesh = createEmptyMesh();
+            deformableMeshes[deformable] = VirtualMeshContext(mesh);
+            deformable.vertices = null;
+            deformable.vertexMapDirty = false;
+            deformable.deselectAll();
+            deformable.refreshMesh();
+        }
+    }
+
     void refreshMeshView(IncMeshEditorOne impl, IncMesh mesh) {
         if (auto deformable = cast(IncMeshEditorOneDeformable)impl) {
             auto positions = ngMeshPositions(mesh);
@@ -76,7 +97,38 @@ private:
     void markChanged(IncMeshEditorOne impl) {
         if (auto deformable = cast(IncMeshEditorOneDeformable)impl) {
             deformable.vertexMapDirty = true;
+            oneTimeGridLog("markChanged: target=%s vertices=%s selected=%s tool=%s",
+                deformable.getTarget() ? deformable.getTarget().name : "(null)",
+                deformable.vertices.length,
+                deformable.selected.length,
+                impl.getToolMode());
         }
+    }
+
+    bool applyVirtualMeshToTarget(IncMeshEditorOne impl) {
+        bool isVirtual = false;
+        auto mesh = getMesh(impl, isVirtual);
+        if (!isVirtual || mesh is null)
+            return false;
+        if (mesh.vertices.length == 0 && mesh.axes.length < 2)
+            return false;
+        if (auto deformable = cast(IncMeshEditorOneDeformable)impl) {
+            if (auto target = cast(GridDeformer)deformable.getTarget()) {
+                auto dirtyBefore = deformable.vertexMapDirty;
+                if (dirtyBefore) {
+                    oneTimeGridLog("applyVirtualMeshToTarget: target=%s virtualVertices=%s axes=%s dirtyBefore=%s",
+                        target.name, mesh.vertices.length, mesh.axes.length, dirtyBefore);
+                }
+                applyMeshToTarget(target, mesh.vertices, &mesh);
+                deformable.vertexMapDirty = false;
+                if (dirtyBefore) {
+                    oneTimeGridLog("applyVirtualMeshToTarget: applied targetVertices=%s deformation=%s dirtyAfter=%s",
+                        target.vertices.length, target.deformation.length, deformable.vertexMapDirty);
+                }
+                return true;
+            }
+        }
+        return false;
     }
 
     GridActionID currentAction;
@@ -228,6 +280,13 @@ private:
             meshData.regenerateGrid();
             mesh.copyFromMeshData(meshData);
             refreshMeshView(impl, mesh);
+            markChanged(impl);
+            oneTimeGridLog("create end: target=%s bounds=(%s,%s,%s,%s) vertices=%s axes=%sx%s",
+                impl.getTarget() ? impl.getTarget().name : "(null)",
+                bounds.x, bounds.y, bounds.z, bounds.w,
+                mesh.vertices.length,
+                mesh.axes.length > 0 ? mesh.axes[0].length : 0,
+                mesh.axes.length > 1 ? mesh.axes[1].length : 0);
             currentAction = GridActionID.End;
             return true;
         }
@@ -396,7 +455,7 @@ private:
     override void draw (Camera camera, IncMeshEditorOne impl) {
         bool isVirtual = false;
         auto mesh = getMesh(impl, isVirtual);
-        if (mesh is null || mesh.axes.length != 2)
+        if (mesh is null)
             return;
 
         Vec3Array lines;
@@ -415,6 +474,8 @@ private:
                 lines ~= [vec3(offx, bounds.y, 0), vec3(offx, bounds.w, 0)];
             }
         } else {
+            if (mesh.axes.length != 2)
+                return;
             float minX = mesh.axes[1][0];
             float maxX = mesh.axes[1][$ - 1];
             float minY = mesh.axes[0][0];

--- a/source/nijigenerate/viewport/common/mesheditor/tools/grid.d
+++ b/source/nijigenerate/viewport/common/mesheditor/tools/grid.d
@@ -21,7 +21,6 @@ import nijigenerate.core.dbg;
 import nijilive.core.nodes.deformer.grid : GridDeformer;
 import bindbc.opengl;
 import bindbc.imgui;
-import std.stdio : writefln;
 import std.array;
 import std.algorithm.searching: countUntil;
 import std.algorithm.mutation;
@@ -30,10 +29,6 @@ import std.algorithm.searching : all;
 
 class GridTool : NodeSelect {
 private:
-    void oneTimeGridLog(Args...)(string fmt, Args args) {
-        writefln("[OneTimeDeform/Grid] " ~ fmt, args);
-    }
-
     struct VirtualMeshContext {
         IncMesh mesh;
     }
@@ -97,11 +92,6 @@ private:
     void markChanged(IncMeshEditorOne impl) {
         if (auto deformable = cast(IncMeshEditorOneDeformable)impl) {
             deformable.vertexMapDirty = true;
-            oneTimeGridLog("markChanged: target=%s vertices=%s selected=%s tool=%s",
-                deformable.getTarget() ? deformable.getTarget().name : "(null)",
-                deformable.vertices.length,
-                deformable.selected.length,
-                impl.getToolMode());
         }
     }
 
@@ -114,17 +104,8 @@ private:
             return false;
         if (auto deformable = cast(IncMeshEditorOneDeformable)impl) {
             if (auto target = cast(GridDeformer)deformable.getTarget()) {
-                auto dirtyBefore = deformable.vertexMapDirty;
-                if (dirtyBefore) {
-                    oneTimeGridLog("applyVirtualMeshToTarget: target=%s virtualVertices=%s axes=%s dirtyBefore=%s",
-                        target.name, mesh.vertices.length, mesh.axes.length, dirtyBefore);
-                }
                 applyMeshToTarget(target, mesh.vertices, &mesh);
                 deformable.vertexMapDirty = false;
-                if (dirtyBefore) {
-                    oneTimeGridLog("applyVirtualMeshToTarget: applied targetVertices=%s deformation=%s dirtyAfter=%s",
-                        target.vertices.length, target.deformation.length, deformable.vertexMapDirty);
-                }
                 return true;
             }
         }
@@ -281,12 +262,6 @@ private:
             mesh.copyFromMeshData(meshData);
             refreshMeshView(impl, mesh);
             markChanged(impl);
-            oneTimeGridLog("create end: target=%s bounds=(%s,%s,%s,%s) vertices=%s axes=%sx%s",
-                impl.getTarget() ? impl.getTarget().name : "(null)",
-                bounds.x, bounds.y, bounds.z, bounds.w,
-                mesh.vertices.length,
-                mesh.axes.length > 0 ? mesh.axes[0].length : 0,
-                mesh.axes.length > 1 ? mesh.axes[1].length : 0);
             currentAction = GridActionID.End;
             return true;
         }

--- a/source/nijigenerate/viewport/common/mesheditor/tools/grid.d
+++ b/source/nijigenerate/viewport/common/mesheditor/tools/grid.d
@@ -459,7 +459,7 @@ private:
             return;
 
         Vec3Array lines;
-        vec4 color = vec4(0.2, 0.9, 0.9, 1);
+        vec4 color = impl.edgeColor;
 
         if (currentAction == GridActionID.Create) {
             vec4 bounds = vec4(min(dragOrigin.x, dragEnd.x), min(dragOrigin.y, dragEnd.y),

--- a/source/nijigenerate/viewport/common/mesheditor/tools/onetimedeform.d
+++ b/source/nijigenerate/viewport/common/mesheditor/tools/onetimedeform.d
@@ -3,6 +3,7 @@ module nijigenerate.viewport.common.mesheditor.tools.onetimedeform;
 import nijigenerate.viewport.common.mesheditor.tools.enums;
 import nijigenerate.viewport.common.mesheditor.tools.base;
 import nijigenerate.viewport.common.mesheditor.tools.select;
+import nijigenerate.viewport.common.mesheditor.tools.grid : GridTool;
 import nijigenerate.viewport.common.mesheditor.operations;
 import nijigenerate.viewport.vertex.mesheditor;
 import nijigenerate.viewport.model.mesheditor;
@@ -22,9 +23,10 @@ import nijilive.core.nodes.deformer.grid : GridDeformer;
 import nijigenerate.core.dbg;
 import bindbc.opengl;
 import bindbc.imgui;
-//import std.stdio;
+import std.stdio : writefln;
 import std.algorithm;
 import std.array;
+import std.math : isFinite;
 
 enum SubToolMode {
     Select,
@@ -33,6 +35,10 @@ enum SubToolMode {
 }
 
 private {
+    void oneTimeDeformLog(Args...)(string fmt, Args args) {
+        writefln("[OneTimeDeform] " ~ fmt, args);
+    }
+
     // Map active NodeFilter -> its deform editor to resolve editors during Undo/Redo reliably
     IncMeshEditorOne[NodeFilter] gFilterEditors;
 
@@ -42,10 +48,35 @@ private {
         IncMeshEditorOne defImpl = null;
         int vertActionId = NodeSelect.SelectActionID.None;
         int defActionId  = NodeSelect.SelectActionID.None;
+        SubToolMode currentMode = SubToolMode.Vertex;
+        bool switchModeConsumed = false;
+        int cachedPeekFrame = -1;
+        SubToolMode cachedPeekMode = SubToolMode.Select;
+        int cachedPeekAction = NodeSelect.SelectActionID.None;
+        int cachedUpdateFrame = -1;
+        SubToolMode cachedUpdateMode = SubToolMode.Select;
+        int cachedUpdateAction = NodeSelect.SelectActionID.None;
+        bool cachedUpdateResult = false;
+        bool cachedUpdateChanged = false;
 
     private:
+        struct SaveBindingBackup {
+            DeformationParameterBinding binding;
+            bool bindingAdded;
+            Deformation[][] values;
+            bool[][] isSet;
+        }
+
+        struct SaveTargetFit {
+            Deformable target;
+            DeformationParameterBinding binding;
+            Vec2Array desired;
+            Vec2Array initial;
+        }
+
         Node detachedFilterParent = null;
         ulong detachedFilterOffset = 0;
+        SaveBindingBackup[] saveBackups;
         ActionStackScope actionScope = null;
         bool explicitScopeClose = false;
 
@@ -122,6 +153,8 @@ private {
                 defImpl.addFilterTarget(target);
                 defActionId = NodeSelect.SelectActionID.None;
                 setup!(T);
+                currentMode = SubToolMode.Vertex;
+                invalidatePeekCache();
                 // Register mapping for this filter
                 gFilterEditors[filter] = defImpl;
                 return true;
@@ -129,14 +162,16 @@ private {
             return false;
         }
 
-        void setup(T: MeshGroup)() {
-            vertImpl.setToolMode(VertexToolMode.Grid);
-            defImpl.setToolMode(VertexToolMode.Points);
-        }
-
         void setup(T: GridDeformer)() {
             vertImpl.setToolMode(VertexToolMode.Grid);
-            defImpl.setToolMode(VertexToolMode.Grid);
+            if (auto gridTool = cast(GridTool)vertImpl.getTool())
+                gridTool.resetVirtualMeshAsEmpty(vertImpl);
+            defImpl.setToolMode(VertexToolMode.Points);
+            oneTimeDeformLog("setup GridDeformer: filter=%s vertTool=%s defTool=%s vertVertices=%s defOffsets=%s",
+                filterNode() ? filterNode().name : "(null)",
+                vertImpl.getToolMode(), defImpl.getToolMode(),
+                (cast(IncMeshEditorOneDeformable)vertImpl) ? (cast(IncMeshEditorOneDeformable)vertImpl).vertices.length : 0,
+                defImpl.getOffsets().length);
         }
 
         void setup(T: PathDeformer)() {
@@ -144,7 +179,42 @@ private {
             defImpl.setToolMode(VertexToolMode.BezierDeform);
         }
 
-        void detachForSave(Puppet puppet) {
+        Deformation[][] copyValues(Deformation[][] source) {
+            Deformation[][] result;
+            result.length = source.length;
+            foreach (x; 0 .. source.length) {
+                result[x].length = source[x].length;
+                foreach (y; 0 .. source[x].length)
+                    result[x][y] = source[x][y];
+            }
+            return result;
+        }
+
+        bool[][] copyIsSet(bool[][] source) {
+            bool[][] result;
+            result.length = source.length;
+            foreach (x; 0 .. source.length)
+                result[x] = source[x].dup;
+            return result;
+        }
+
+        DeformationParameterBinding backupTargetBinding(Parameter param, Deformable target) {
+            auto existing = cast(DeformationParameterBinding)param.getBinding(target, "deform");
+            bool bindingAdded = existing is null;
+            auto binding = cast(DeformationParameterBinding)param.getOrAddBinding(target, "deform");
+            if (binding is null)
+                return null;
+
+            saveBackups ~= SaveBindingBackup(
+                binding,
+                bindingAdded,
+                bindingAdded ? null : copyValues(binding.values),
+                bindingAdded ? null : copyIsSet(binding.isSet_)
+            );
+            return binding;
+        }
+
+        void detachFilterNodeForSave(Puppet puppet) {
             auto node = filterNode();
             if (node is null || node.parent is null || node.puppet !is puppet)
                 return;
@@ -155,7 +225,116 @@ private {
             node.reparent(null, 0, true);
         }
 
+        void flushCurrentSubToolForSave() {
+            if (!active())
+                return;
+
+            auto parameter = incArmedParameter();
+            final switch (currentMode) {
+            case SubToolMode.Select:
+                break;
+            case SubToolMode.Vertex:
+                if (vertImpl) {
+                    applyVertexToolToFilter();
+                }
+                break;
+            case SubToolMode.Deform:
+                if (defImpl && parameter) {
+                    auto deform = cast(DeformationParameterBinding)parameter.getOrAddBinding(cast(Node)filter, "deform");
+                    if (deform !is null) {
+                        auto offsets = defImpl.getOffsets();
+                        normalizeDeformationBinding(deform, offsets.length);
+                        deform.update(parameter.findClosestKeypoint(), offsets);
+                        parameter.update();
+                        incActivePuppet().update();
+                    }
+                }
+                break;
+            }
+        }
+
+        bool applyVertexToolToFilter() {
+            if (!vertImpl)
+                return false;
+
+            bool applied = false;
+            if (auto gridTool = cast(GridTool)vertImpl.getTool()) {
+                oneTimeDeformLog("applyVertexToolToFilter: before target=%s dirty=%s vertices=%s",
+                    vertImpl.getTarget() ? vertImpl.getTarget().name : "(null)",
+                    vertImpl.vertexMapDirty,
+                    (cast(IncMeshEditorOneDeformable)vertImpl) ? (cast(IncMeshEditorOneDeformable)vertImpl).vertices.length : 0);
+                applied = gridTool.applyVirtualMeshToTarget(vertImpl);
+                oneTimeDeformLog("applyVertexToolToFilter: grid applied=%s targetVertices=%s targetDeformation=%s",
+                    applied,
+                    (cast(Deformable)vertImpl.getTarget()) ? (cast(Deformable)vertImpl.getTarget()).vertices.length : 0,
+                    (cast(Deformable)vertImpl.getTarget()) ? (cast(Deformable)vertImpl.getTarget()).deformation.length : 0);
+                if (!applied)
+                    return false;
+            } else {
+                vertImpl.applyToTarget();
+                applied = true;
+            }
+
+            if (auto parameter = incArmedParameter())
+                parameter.update();
+            incActivePuppet().update();
+            vertImpl.vertexMapDirty = false;
+            return applied;
+        }
+
+        void detachForSave(Puppet puppet) {
+            auto node = filterNode();
+            if (node is null || node.puppet !is puppet)
+                return;
+
+            flushCurrentSubToolForSave();
+
+            auto param = incArmedParameter();
+            if (param is null) {
+                detachFilterNodeForSave(puppet);
+                return;
+            }
+
+            SaveTargetFit[] fits;
+            auto kp = param.findClosestKeypoint();
+            foreach (child; node.children) {
+                auto deformable = cast(Deformable)child;
+                if (deformable is null)
+                    continue;
+                auto binding = backupTargetBinding(param, deformable);
+                if (binding is null)
+                    continue;
+                Vec2Array initial = binding.getValue(kp).vertexOffsets.dup;
+                initial.length = deformable.vertices.length;
+                Vec2Array desired = deformable.deformation.dup;
+                desired.length = deformable.vertices.length;
+                fits ~= SaveTargetFit(deformable, binding, desired, initial);
+            }
+
+            detachFilterNodeForSave(puppet);
+            param.update();
+            incActivePuppet().update();
+
+            foreach (fit; fits)
+                fitOffsetsForFinalResult(param, fit.binding, kp, fit.target, fit.initial, fit.desired);
+        }
+
         void restoreAfterSave(Puppet puppet) {
+            foreach (backup; saveBackups) {
+                if (backup.binding is null)
+                    continue;
+                auto param = backup.binding.parameter;
+                if (backup.bindingAdded) {
+                    if (param)
+                        param.removeBinding(backup.binding);
+                } else {
+                    backup.binding.values = backup.values;
+                    backup.binding.isSet_ = backup.isSet;
+                    backup.binding.reInterpolate();
+                }
+            }
+            saveBackups.length = 0;
+
             auto node = filterNode();
             if (node is null || detachedFilterParent is null)
                 return;
@@ -163,6 +342,10 @@ private {
             node.reparent(detachedFilterParent, detachedFilterOffset, true);
             detachedFilterParent = null;
             detachedFilterOffset = 0;
+
+            if (auto param = incArmedParameter())
+                param.update();
+            incActivePuppet().update();
         }
 
         void cleanupTarget(IncMeshEditorOne impl, bool allTargets) {
@@ -188,8 +371,25 @@ private {
                     gFilterEditors.remove(filter);
                 node.reparent(null, 0);
                 filter = null;
+                switchModeConsumed = false;
+                invalidatePeekCache();
                 closeActionScope();
             }
+        }
+
+        void invalidatePeekCache() {
+            cachedPeekFrame = -1;
+            cachedPeekAction = NodeSelect.SelectActionID.None;
+            cachedUpdateFrame = -1;
+            cachedUpdateAction = NodeSelect.SelectActionID.None;
+            cachedUpdateResult = false;
+            cachedUpdateChanged = false;
+        }
+
+        void resetCurrentTool(IncMeshEditorOne impl) {
+            if (impl is null || impl.getTool() is null)
+                return;
+            impl.getTool().setToolMode(impl.getToolMode(), impl);
         }
 
         void leaveSubTool(SubToolMode current) {
@@ -200,9 +400,7 @@ private {
             case SubToolMode.Vertex:
                 if (vertImpl) {
                     vertImpl.pushDeformAction();
-                    vertImpl.applyToTarget();
-                    auto parameter = incArmedParameter();
-                    if (parameter) parameter.update();
+                    applyVertexToolToFilter();
                 }
                 break;
             case SubToolMode.Deform:
@@ -214,6 +412,14 @@ private {
 
         void enterSubTool(T)(SubToolMode next) {
             if (!active()) return;
+            oneTimeDeformLog("enterSubTool: %s -> %s filter=%s filterVertices=%s filterDeformation=%s defOffsetsBefore=%s",
+                currentMode, next,
+                filterNode() ? filterNode().name : "(null)",
+                (cast(Deformable)filter) ? (cast(Deformable)filter).vertices.length : 0,
+                (cast(Deformable)filter) ? (cast(Deformable)filter).deformation.length : 0,
+                defImpl ? defImpl.getOffsets().length : 0);
+            currentMode = next;
+            invalidatePeekCache();
             final switch (next) {
             case SubToolMode.Select:
                 break;
@@ -222,7 +428,7 @@ private {
                 vertImpl.edgeColor   = vec4(0, 1, 1, 1);
                 defImpl.vertexColor = vec4(0, 0.5, 0, 1);
                 defImpl.edgeColor   = vec4(0, 0.5, 0, 0.5);
-                vertImpl.setToolMode(vertImpl.getToolMode());
+                resetCurrentTool(vertImpl);
                 vertImpl.getCleanDeformAction();
                 break;
             case SubToolMode.Deform:
@@ -230,11 +436,24 @@ private {
                 vertImpl.edgeColor   = vec4(0, 0.5, 0.5, 0.5);
                 defImpl.vertexColor = vec4(0, 1, 0, 1);
                 defImpl.edgeColor   = vec4(0, 1, 0, 1);
-                defImpl.setToolMode(defImpl.getToolMode());
+                resetCurrentTool(defImpl);
                 defImpl.setTarget(cast(T)filter);
                 defImpl.getCleanDeformAction();
                 seedViewFromBinding();
+                oneTimeDeformLog("enterSubTool Deform ready: defTarget=%s offsets=%s selected=%s vtxAtMouse=%s",
+                    defImpl.getTarget() ? defImpl.getTarget().name : "(null)",
+                    defImpl.getOffsets().length,
+                    defImpl.selected.length,
+                    defImpl.vtxAtMouse);
                 break;
+            }
+        }
+
+        void ensureSubToolReady(T)(SubToolMode next) {
+            if (!active()) return;
+            if (currentMode != next) {
+                enterSubTool!T(next);
+                return;
             }
         }
 
@@ -258,6 +477,133 @@ private {
                 }
                 defImpl.applyOffsets(offs);
             }
+        }
+
+        void normalizeDeformationBinding(DeformationParameterBinding binding, size_t length) {
+            if (binding is null)
+                return;
+            foreach (x; 0 .. binding.values.length) {
+                foreach (y; 0 .. binding.values[x].length) {
+                    auto offsets = binding.values[x][y].vertexOffsets.dup;
+                    if (offsets.length == length)
+                        continue;
+                    Vec2Array resized;
+                    resized.length = length;
+                    auto count = min(offsets.length, length);
+                    foreach (i; 0 .. count)
+                        resized[i] = offsets[i];
+                    foreach (i; count .. length)
+                        resized[i] = vec2(0);
+                    binding.values[x][y].vertexOffsets = resized;
+                }
+            }
+        }
+
+        float squaredError(Vec2Array lhs, Vec2Array rhs) {
+            auto count = min(lhs.length, rhs.length);
+            if (count == 0) return float.max;
+            double total = 0;
+            foreach (i; 0 .. count) {
+                auto d = lhs[i] - rhs[i];
+                if (!isFinite(d.x) || !isFinite(d.y))
+                    return float.max;
+                total += cast(double)d.x * d.x + cast(double)d.y * d.y;
+            }
+            return cast(float)(total / count);
+        }
+
+        Vec2Array evaluateWithCandidate(Parameter param, DeformationParameterBinding binding, vec2u keypoint, Vec2Array candidate) {
+            normalizeDeformationBinding(binding, candidate.length);
+            binding.update(keypoint, candidate);
+            param.update();
+            incActivePuppet().update();
+
+            auto target = cast(Deformable)binding.targetNode;
+            return target ? target.deformation.dup : Vec2Array.init;
+        }
+
+        Vec2Array fitOffsetsForFinalResult(Parameter param, DeformationParameterBinding binding, vec2u keypoint, Deformable target, Vec2Array initial, Vec2Array desired) {
+            if (desired.length != target.vertices.length)
+                return initial;
+
+            Vec2Array candidate = initial.dup;
+            candidate.length = desired.length;
+
+            auto evaluated = evaluateWithCandidate(param, binding, keypoint, candidate);
+            float currentError = squaredError(evaluated, desired);
+            Vec2Array best = candidate.dup;
+            float bestError = currentError;
+            float step = 1.0f;
+
+            enum MaxIterations = 10;
+            enum MinStep = 0.015625f;
+            enum Epsilon = 0.0001f;
+
+            foreach (_; 0 .. MaxIterations) {
+                if (bestError <= Epsilon)
+                    break;
+
+                Vec2Array trial = candidate.dup;
+                auto count = min(trial.length, desired.length, evaluated.length);
+                foreach (i; 0 .. count) {
+                    trial[i] += (desired[i] - evaluated[i]) * step;
+                }
+
+                auto trialEvaluated = evaluateWithCandidate(param, binding, keypoint, trial);
+                float trialError = squaredError(trialEvaluated, desired);
+                if (trialError < currentError) {
+                    candidate = trial;
+                    evaluated = trialEvaluated;
+                    currentError = trialError;
+                    if (trialError < bestError) {
+                        best = trial.dup;
+                        bestError = trialError;
+                    }
+                    step = min(step * 1.25f, 1.0f);
+                } else {
+                    step *= 0.5f;
+                    if (step < MinStep)
+                        break;
+                }
+            }
+
+            binding.update(keypoint, best);
+            param.update();
+            incActivePuppet().update();
+            return best;
+        }
+
+        void applyToTargetsWithFitting(Parameter param, vec2u keypoint) {
+            struct TargetFit {
+                Deformable target;
+                DeformationParameterBinding binding;
+                Vec2Array desired;
+                Vec2Array initial;
+            }
+
+            TargetFit[] fits;
+            foreach (child; filterNode().children) {
+                auto deformable = cast(Deformable)child;
+                if (deformable is null)
+                    continue;
+                auto binding = cast(DeformationParameterBinding)param.getOrAddBinding(deformable, "deform");
+                if (binding is null)
+                    continue;
+                Vec2Array initial = binding.getValue(keypoint).vertexOffsets.dup;
+                initial.length = deformable.vertices.length;
+                Vec2Array desired = deformable.deformation.dup;
+                desired.length = deformable.vertices.length;
+                fits ~= TargetFit(deformable, binding, desired, initial);
+            }
+
+            foreach (child; filterNode().children.dup)
+                filter.releaseTarget(child);
+
+            if (auto filterBinding = param.getBinding(cast(Node)filter, "deform"))
+                param.removeBinding(filterBinding);
+
+            foreach (fit; fits)
+                fitOffsetsForFinalResult(param, fit.binding, keypoint, fit.target, fit.initial, fit.desired);
         }
     }
 
@@ -287,12 +633,17 @@ private {
         if (activeScope)
             activeScope.onActionScopeClosed();
     }
-}
 
-shared static this() {
-    incRegisterSaveFunc(&ngDetachOneTimeDeformFilterForSave);
-    ngRegisterPostSaveFunc(&ngRestoreOneTimeDeformFilterAfterSave);
-    ngRegisterActionStackScopeCloseHandler(ActionStackScopeUnit.OneTimeDeform, &ngOnOneTimeDeformScopeClosed);
+    bool registeredCallbacks = false;
+
+    void ngEnsureOneTimeDeformCallbacks() {
+        if (registeredCallbacks)
+            return;
+        registeredCallbacks = true;
+        incRegisterSaveFunc(&ngDetachOneTimeDeformFilterForSave);
+        ngRegisterPostSaveFunc(&ngRestoreOneTimeDeformFilterAfterSave);
+        ngRegisterActionStackScopeCloseHandler(ActionStackScopeUnit.OneTimeDeform, &ngOnOneTimeDeformScopeClosed);
+    }
 }
 
 class OneTimeDeformBase :  NodeSelect {
@@ -302,7 +653,7 @@ class OneTimeDeformBase :  NodeSelect {
     bool acquired = false;
 
     enum OneTimeDeformActionID {
-        SwitchMode = cast(int)(SelectActionID.End),
+        SwitchMode = 10_000,
         End
     }
 
@@ -386,11 +737,23 @@ public:
     override
     void setToolMode(VertexToolMode toolMode, IncMeshEditorOne impl) {
         super.setToolMode(toolMode, impl);
+        ngEnsureOneTimeDeformCallbacks();
         auto session = ngOneTimeDeformScope();
         session.initialize!T(impl.getTarget());
         acquired = session.active();
+        if (session.vertImpl && !session.vertImpl.getFilterTargets().canFind(impl.getTarget()))
+            session.vertImpl.addFilterTarget(impl.getTarget());
+        if (session.defImpl && !session.defImpl.getFilterTargets().canFind(impl.getTarget()))
+            session.defImpl.addFilterTarget(impl.getTarget());
         if ((cast(T)session.filter).children.countUntil(impl.getTarget()) < 0) {
             session.filter.captureTarget(impl.getTarget());
+            // captureTarget changes the filter mesh. The inner editors were
+            // created before capture, so refresh them before any subtool uses
+            // hit-testing or offsets against the filter.
+            if (session.defImpl) {
+                session.defImpl.setTarget(cast(T)session.filter);
+                session.defImpl.setToolMode(session.defImpl.getToolMode());
+            }
         }
         impl.getDeformAction();
         session.begin();
@@ -424,13 +787,16 @@ public:
                     import nijigenerate.actions.parameter : ParameterChangeBindingsValueAction;
                     auto persistAction = new ParameterChangeBindingsValueAction(_("apply deform"), param, bindings, kp.x, kp.y);
 
-                    // Apply changes to children, then capture new values
-                    session.filter.applyDeformToChildren([param], false);
+                    // Fit the baked target offsets so the existing downstream
+                    // deformers reproduce the final one-time edit result.
+                    session.applyToTargetsWithFitting(param, kp);
                     persistAction.updateNewState();
                     incActionPush(persistAction);
                 } else {
-                    // No bindings to persist; still apply to ensure state consistency
-                    session.filter.applyDeformToChildren([param], false);
+                    foreach (child; session.filterNode().children.dup)
+                        session.filter.releaseTarget(child);
+                    if (auto filterBinding = param.getBinding(cast(Node)session.filter, "deform"))
+                        param.removeBinding(filterBinding);
                 }
 
                 session.cleanupTarget(impl, true);
@@ -453,19 +819,37 @@ public:
             return OneTimeDeformActionID.SwitchMode;
         }
 
+        int peekSharedSubTool(OneTimeDeformScope session, SubToolMode subMode, int delegate() evaluate) {
+            auto frame = igGetFrameCount();
+            if (session.cachedPeekFrame == frame && session.cachedPeekMode == subMode)
+                return session.cachedPeekAction;
+            auto action = evaluate();
+            session.cachedPeekFrame = frame;
+            session.cachedPeekMode = subMode;
+            session.cachedPeekAction = action;
+            return action;
+        }
+
         switch (mode) {
         case SubToolMode.Select:
             return super.peek(io, impl);
         case SubToolMode.Vertex:
-            if (acquired)
-                ngOneTimeDeformScope().vertActionId = ngOneTimeDeformScope().vertImpl.getTool().peek(io, ngOneTimeDeformScope().vertImpl);
+            if (acquired) {
+                auto session = ngOneTimeDeformScope();
+                return session.vertActionId = peekSharedSubTool(session, mode, () {
+                    return session.vertImpl.getTool().peek(io, session.vertImpl);
+                });
+            }
             break;
         case SubToolMode.Deform:
             if (acquired) {
+                auto session = ngOneTimeDeformScope();
                 version(assert) {
-                    assert(ngOneTimeDeformScope().defImpl !is null, "Deform editor missing on peek");
+                    assert(session.defImpl !is null, "Deform editor missing on peek");
                 }
-                ngOneTimeDeformScope().defActionId = ngOneTimeDeformScope().defImpl.getTool().peek(io, ngOneTimeDeformScope().defImpl);
+                return session.defActionId = peekSharedSubTool(session, mode, () {
+                    return session.defImpl.getTool().peek(io, session.defImpl);
+                });
             }
             break;
         default:
@@ -476,42 +860,76 @@ public:
 
     override
     int unify(int[] actions) {
-        int[int] priorities;
-        priorities[OneTimeDeformActionID.SwitchMode] = 0;
-        priorities[SelectActionID.None]                 = 10;
-        priorities[SelectActionID.SelectArea]           = 5;
-        priorities[SelectActionID.ToggleSelect]         = 2;
-        priorities[SelectActionID.SelectOne]            = 2;
-        priorities[SelectActionID.MaybeSelectOne]       = 2;
-        priorities[SelectActionID.StartDrag]            = 2;
-        priorities[SelectActionID.SelectMaybeSelectOne] = 2;
-
-        int action = SelectActionID.None;
-        int curPriority = priorities[action];
         foreach (a; actions) {
-            auto newPriority = priorities[a];
-            if (newPriority < curPriority) {
-                curPriority = newPriority;
-                action = a;
-            }
+            if (a == OneTimeDeformActionID.SwitchMode)
+                return OneTimeDeformActionID.SwitchMode;
         }
-        return action;
+
+        auto session = ngActiveOneTimeDeformScope();
+        final switch (mode) {
+        case SubToolMode.Select:
+            return super.unify(actions);
+        case SubToolMode.Vertex:
+            if (acquired && session && session.vertImpl)
+                return session.vertImpl.getTool().unify(actions);
+            break;
+        case SubToolMode.Deform:
+            if (acquired && session && session.defImpl)
+                return session.defImpl.getTool().unify(actions);
+            break;
+        }
+        return SelectActionID.None;
     }
 
     override bool update(ImGuiIO* io, IncMeshEditorOne impl, int action, out bool changed) {
         incStatusTooltip(_("Switch Mode"), _("TAB"));
+
+        bool updateSharedSubTool(OneTimeDeformScope session, SubToolMode subMode, int subAction, bool delegate(out bool) evaluate, out bool subChanged) {
+            auto frame = igGetFrameCount();
+            if (session.cachedUpdateFrame == frame &&
+                session.cachedUpdateMode == subMode &&
+                session.cachedUpdateAction == subAction) {
+                subChanged = session.cachedUpdateChanged;
+                return session.cachedUpdateResult;
+            }
+
+            bool localChanged = false;
+            auto result = evaluate(localChanged);
+            session.cachedUpdateFrame = frame;
+            session.cachedUpdateMode = subMode;
+            session.cachedUpdateAction = subAction;
+            session.cachedUpdateResult = result;
+            session.cachedUpdateChanged = localChanged;
+            subChanged = localChanged;
+            return result;
+        }
 
         // Apply side-effects if mode changed externally (e.g., via Undo/Redo of mode action)
         if (appliedMode != mode) {
             ngOneTimeDeformScope().enterSubTool!T(mode);
             appliedMode = mode;
         }
+        auto readySession = ngOneTimeDeformScope();
+        if (acquired)
+            readySession.ensureSubToolReady!T(mode);
+
+        auto sessionForAction = ngOneTimeDeformScope();
+        if (action != OneTimeDeformActionID.SwitchMode)
+            sessionForAction.switchModeConsumed = false;
 
         if (action == OneTimeDeformActionID.SwitchMode) {
+            if (sessionForAction.switchModeConsumed)
+                return false;
+            sessionForAction.switchModeConsumed = true;
+            oneTimeDeformLog("switch action start: outerTarget=%s mode=%s currentMode=%s acquired=%s",
+                impl.getTarget() ? impl.getTarget().name : "(null)",
+                mode,
+                sessionForAction.currentMode,
+                acquired);
             // Group persistence + mode change into one undo step
             incActionPushGroup();
             // Capture per-target old/new modes to keep UI mode flips in history.
-            auto session = ngOneTimeDeformScope();
+            auto session = sessionForAction;
             Node[] targets = session.defImpl ? session.defImpl.getFilterTargets() : (session.vertImpl ? session.vertImpl.getFilterTargets() : null);
             SubToolMode[] oldModes;
             SubToolMode[] newModes;
@@ -530,16 +948,33 @@ public:
                 }
             }
 
+            SubToolMode nextMode = mode;
             final switch (mode) {
             case SubToolMode.Select:
-                switchSubTool(SubToolMode.Vertex);
+                nextMode = SubToolMode.Vertex;
                 break;
             case SubToolMode.Vertex:
-                switchSubTool(SubToolMode.Deform);
+                nextMode = SubToolMode.Deform;
                 break;
             case SubToolMode.Deform:
-                switchSubTool(SubToolMode.Vertex);
+                nextMode = SubToolMode.Vertex;
                 break;
+            }
+            switchSubTool(nextMode);
+            oneTimeDeformLog("switch action applied: nextMode=%s currentMode=%s filterVertices=%s defOffsets=%s",
+                nextMode,
+                session.currentMode,
+                (cast(Deformable)session.filter) ? (cast(Deformable)session.filter).vertices.length : 0,
+                session.defImpl ? session.defImpl.getOffsets().length : 0);
+            if (targets && targets.length > 0 && newModes.length == targets.length) {
+                foreach (i, t; targets) {
+                    auto ed = ngGetEditorFor(t);
+                    auto tool = ed ? cast(OneTimeDeformBase)ed.getTool() : null;
+                    if (tool is null)
+                        continue;
+                    tool.mode = newModes[i];
+                    tool.appliedMode = newModes[i];
+                }
             }
             // Push mode change action after switching internal state, so redo/undo reflect UI mode.
             import nijigenerate.actions.mesheditor : SubToolModeChangeAction;
@@ -558,28 +993,44 @@ public:
         case SubToolMode.Vertex:
             if (acquired) {
                 auto session = ngOneTimeDeformScope();
-                bool result = session.vertImpl.getTool().update(io, session.vertImpl, session.vertActionId, changed);
+                bool result = updateSharedSubTool(session, mode, action, (out bool localChanged) {
+                    return session.vertImpl.getTool().update(io, session.vertImpl, action, localChanged);
+                }, changed);
                 // When vertex count or map updates, transfer deformation to the current shape accurately
-                if (session.vertImpl.vertexMapDirty) {
-                    session.vertImpl.applyToTarget();
-                    auto parameter = incArmedParameter();
-                    if (parameter) parameter.update();
-                    session.vertImpl.vertexMapDirty = false;
-                }
+                if (session.vertImpl.vertexMapDirty)
+                    session.applyVertexToolToFilter();
                 return result;
             }
             break;
         case SubToolMode.Deform:
             if (acquired) {
                 auto session = ngOneTimeDeformScope();
-                bool result = session.defImpl.getTool().update(io, session.defImpl, session.defActionId, changed);
-                // 1-frame delayed write to binding: apply last frame's offsets now
-                if (result) {
+                bool result = updateSharedSubTool(session, mode, action, (out bool localChanged) {
+                    return session.defImpl.getTool().update(io, session.defImpl, action, localChanged);
+                }, changed);
+                if (action != SelectActionID.None || changed) {
+                    oneTimeDeformLog("update Deform: target=%s action=%s changed=%s result=%s defOffsets=%s selected=%s vtxAtMouse=%s mouse=(%s,%s)",
+                        impl.getTarget() ? impl.getTarget().name : "(null)",
+                        action,
+                        changed,
+                        result,
+                        session.defImpl ? session.defImpl.getOffsets().length : 0,
+                        session.defImpl ? session.defImpl.selected.length : 0,
+                        session.defImpl ? session.defImpl.vtxAtMouse : ulong.max,
+                        session.defImpl ? session.defImpl.mousePos.x : 0,
+                        session.defImpl ? session.defImpl.mousePos.y : 0);
+                }
+                if (changed) {
                     auto parameter = incArmedParameter();
                     if (parameter) {
                         auto deform = cast(DeformationParameterBinding)parameter.getOrAddBinding(cast(T)session.filter, "deform");
-                        if (deform !is null)
-                            deform.update(parameter.findClosestKeypoint(), session.defImpl.getOffsets());
+                        if (deform !is null) {
+                            auto offsets = session.defImpl.getOffsets();
+                            session.normalizeDeformationBinding(deform, offsets.length);
+                            deform.update(parameter.findClosestKeypoint(), offsets);
+                            parameter.update();
+                            incActivePuppet().update();
+                        }
                     }
                     session.defImpl.markActionDirty();
                 }
@@ -614,7 +1065,7 @@ public:
     }
 }
 
-class ToolInfoImpl(T: OneTimeDeform!MeshGroup) : ToolInfoBase!(T) {
+class ToolInfoImpl(T: OneTimeDeform!GridDeformer) : ToolInfoBase!(T) {
     override
     bool viewportTools(bool deformOnly, VertexToolMode toolMode, IncMeshEditorOne[Node] editors) {
         if (deformOnly)
@@ -622,9 +1073,9 @@ class ToolInfoImpl(T: OneTimeDeform!MeshGroup) : ToolInfoBase!(T) {
         return false;
     }
     override bool canUse(bool deformOnly, Node[] targets) { return deformOnly; }
-    override VertexToolMode mode() { return VertexToolMode.AltMeshGroup; };
+    override VertexToolMode mode() { return VertexToolMode.AltGridDeform; };
     override string icon() { return "";}
-    override string description() { return _("Mesh deformation");}
+    override string description() { return _("Grid deformation");}
 }
 
 class ToolInfoImpl(T: OneTimeDeform!PathDeformer) : ToolInfoBase!(T) {

--- a/source/nijigenerate/viewport/common/mesheditor/tools/onetimedeform.d
+++ b/source/nijigenerate/viewport/common/mesheditor/tools/onetimedeform.d
@@ -33,75 +33,266 @@ enum SubToolMode {
 }
 
 private {
-    NodeFilter filter = null;
-    IncMeshEditorOne fVertImpl = null;
-    IncMeshEditorOne fDefImpl = null;
-    int vertActionId = 0;
-    int defActionId  = 0;
     // Map active NodeFilter -> its deform editor to resolve editors during Undo/Redo reliably
     IncMeshEditorOne[NodeFilter] gFilterEditors;
 
-    void forceFinalize(Node target) {
-        if (filter) {
-            // Remove mapping first to avoid stale lookups
-            if (cast(NodeFilter)filter in gFilterEditors)
-                gFilterEditors.remove(cast(NodeFilter)filter);
-            foreach (child; (cast(Node)filter).children) {
-                filter.applyDeformToChildren([incArmedParameter()], false);
-                filter.releaseTarget(child);
-            }
-            if (fVertImpl)
-                fVertImpl.removeFilterTarget(target);
-            if (fDefImpl)
-                fDefImpl.removeFilterTarget(target);
-            if ((cast(Node)filter).children.length == 0) {
-                (cast(Node)filter).reparent(null, 0);
-                filter = null;
-            }
-            incViewportNodeDeformNotifyParamValueChanged();
-        }        
-    }
+    final class OneTimeDeformScope {
+        NodeFilter filter = null;
+        IncMeshEditorOne vertImpl = null;
+        IncMeshEditorOne defImpl = null;
+        int vertActionId = NodeSelect.SelectActionID.None;
+        int defActionId  = NodeSelect.SelectActionID.None;
 
-    bool initialize(T)(Node target, Node currTarget = null) {
-        if (filter is null || cast(T)filter is null) {
-            if (filter)
-                forceFinalize(currTarget);
-            filter = new T(incActivePuppet().root);
-            fVertImpl = new IncMeshEditorOneFor!(T, EditMode.VertexEdit);
-            fVertImpl.vertexColor = vec4(0, 1, 1, 1);
-            fVertImpl.edgeColor   = vec4(0, 1, 1, 1);
-            fVertImpl.setTarget(cast(T)filter);
-            fVertImpl.addFilterTarget(target);
-            vertActionId = NodeSelect.SelectActionID.None;
+    private:
+        Node detachedFilterParent = null;
+        ulong detachedFilterOffset = 0;
+        ActionStackScope actionScope = null;
+        bool explicitScopeClose = false;
 
-            fDefImpl  = new IncMeshEditorOneFor!(T, EditMode.ModelEdit);
-            fDefImpl.vertexColor = vec4(0, 1, 0, 1);
-            fDefImpl.edgeColor   = vec4(0, 1, 0, 1);
-            fDefImpl.setTarget(cast(T)filter);
-            fDefImpl.addFilterTarget(target);
-            defActionId = NodeSelect.SelectActionID.None;
-            setup!(T);
-            // Register mapping for this filter
-            gFilterEditors[cast(NodeFilter)filter] = fDefImpl;
-            return true;
+    public:
+        Node filterNode() {
+            return cast(Node)filter;
         }
-        return false;
+
+        bool active() {
+            return filter !is null;
+        }
+
+        void begin() {
+            if (actionScope is null)
+                actionScope = ngOpenActionStackScope(ActionStackScopeUnit.OneTimeDeform);
+        }
+
+        void closeActionScope() {
+            if (actionScope) {
+                explicitScopeClose = true;
+                scope(exit) explicitScopeClose = false;
+                auto closing = actionScope;
+                actionScope = null;
+                closing.close();
+            }
+        }
+
+        void onActionScopeClosed() {
+            if (explicitScopeClose) return;
+            actionScope = null;
+            cleanupTarget(null, true);
+            if (filter is null)
+                activeScope = null;
+        }
+
+        void forceFinalize(Node target) {
+            if (filter) {
+                closeActionScope();
+                // Remove mapping first to avoid stale lookups
+                if (filter in gFilterEditors)
+                    gFilterEditors.remove(filter);
+                foreach (child; filterNode().children.dup) {
+                    filter.applyDeformToChildren([incArmedParameter()], false);
+                    filter.releaseTarget(child);
+                }
+                if (vertImpl)
+                    vertImpl.removeFilterTarget(target);
+                if (defImpl)
+                    defImpl.removeFilterTarget(target);
+                if (filterNode().children.length == 0) {
+                    filterNode().reparent(null, 0);
+                    filter = null;
+                }
+                incViewportNodeDeformNotifyParamValueChanged();
+            }
+        }
+
+        bool initialize(T)(Node target, Node currTarget = null) {
+            if (filter is null || cast(T)filter is null) {
+                if (filter)
+                    forceFinalize(currTarget);
+                filter = new T(incActivePuppet().root);
+                vertImpl = new IncMeshEditorOneFor!(T, EditMode.VertexEdit);
+                vertImpl.vertexColor = vec4(0, 1, 1, 1);
+                vertImpl.edgeColor   = vec4(0, 1, 1, 1);
+                vertImpl.setTarget(cast(T)filter);
+                vertImpl.addFilterTarget(target);
+                vertActionId = NodeSelect.SelectActionID.None;
+
+                defImpl  = new IncMeshEditorOneFor!(T, EditMode.ModelEdit);
+                defImpl.vertexColor = vec4(0, 1, 0, 1);
+                defImpl.edgeColor   = vec4(0, 1, 0, 1);
+                defImpl.setTarget(cast(T)filter);
+                defImpl.addFilterTarget(target);
+                defActionId = NodeSelect.SelectActionID.None;
+                setup!(T);
+                // Register mapping for this filter
+                gFilterEditors[filter] = defImpl;
+                return true;
+            }
+            return false;
+        }
+
+        void setup(T: MeshGroup)() {
+            vertImpl.setToolMode(VertexToolMode.Grid);
+            defImpl.setToolMode(VertexToolMode.Points);
+        }
+
+        void setup(T: GridDeformer)() {
+            vertImpl.setToolMode(VertexToolMode.Grid);
+            defImpl.setToolMode(VertexToolMode.Grid);
+        }
+
+        void setup(T: PathDeformer)() {
+            vertImpl.setToolMode(VertexToolMode.BezierDeform);
+            defImpl.setToolMode(VertexToolMode.BezierDeform);
+        }
+
+        void detachForSave(Puppet puppet) {
+            auto node = filterNode();
+            if (node is null || node.parent is null || node.puppet !is puppet)
+                return;
+
+            detachedFilterParent = node.parent;
+            auto offset = detachedFilterParent.children.countUntil(node);
+            detachedFilterOffset = offset >= 0 ? cast(ulong)offset : Node.OFFSET_END;
+            node.reparent(null, 0, true);
+        }
+
+        void restoreAfterSave(Puppet puppet) {
+            auto node = filterNode();
+            if (node is null || detachedFilterParent is null)
+                return;
+
+            node.reparent(detachedFilterParent, detachedFilterOffset, true);
+            detachedFilterParent = null;
+            detachedFilterOffset = 0;
+        }
+
+        void cleanupTarget(IncMeshEditorOne impl, bool allTargets) {
+            if (filter is null) return;
+
+            auto node = filterNode();
+            if (allTargets) {
+                foreach (child; node.children.dup) {
+                    filter.releaseTarget(child);
+                }
+            } else if (impl && impl.getTarget() !is null) {
+                if (node.children.countUntil(impl.getTarget()) >= 0)
+                    filter.releaseTarget(impl.getTarget());
+            }
+
+            if (vertImpl && impl)
+                vertImpl.removeFilterTarget(impl.getTarget());
+            if (defImpl && impl)
+                defImpl.removeFilterTarget(impl.getTarget());
+
+            if (node.children.length == 0) {
+                if (filter in gFilterEditors)
+                    gFilterEditors.remove(filter);
+                node.reparent(null, 0);
+                filter = null;
+                closeActionScope();
+            }
+        }
+
+        void leaveSubTool(SubToolMode current) {
+            if (!active()) return;
+            final switch (current) {
+            case SubToolMode.Select:
+                break;
+            case SubToolMode.Vertex:
+                if (vertImpl) {
+                    vertImpl.pushDeformAction();
+                    vertImpl.applyToTarget();
+                    auto parameter = incArmedParameter();
+                    if (parameter) parameter.update();
+                }
+                break;
+            case SubToolMode.Deform:
+                if (defImpl)
+                    defImpl.pushDeformAction();
+                break;
+            }
+        }
+
+        void enterSubTool(T)(SubToolMode next) {
+            if (!active()) return;
+            final switch (next) {
+            case SubToolMode.Select:
+                break;
+            case SubToolMode.Vertex:
+                vertImpl.vertexColor = vec4(0, 1, 1, 1);
+                vertImpl.edgeColor   = vec4(0, 1, 1, 1);
+                defImpl.vertexColor = vec4(0, 0.5, 0, 1);
+                defImpl.edgeColor   = vec4(0, 0.5, 0, 0.5);
+                vertImpl.setToolMode(vertImpl.getToolMode());
+                vertImpl.getCleanDeformAction();
+                break;
+            case SubToolMode.Deform:
+                vertImpl.vertexColor = vec4(0, 0.5, 0.5, 1);
+                vertImpl.edgeColor   = vec4(0, 0.5, 0.5, 0.5);
+                defImpl.vertexColor = vec4(0, 1, 0, 1);
+                defImpl.edgeColor   = vec4(0, 1, 0, 1);
+                defImpl.setToolMode(defImpl.getToolMode());
+                defImpl.setTarget(cast(T)filter);
+                defImpl.getCleanDeformAction();
+                seedViewFromBinding();
+                break;
+            }
+        }
+
+        void seedViewFromBinding() {
+            auto parameter = incArmedParameter();
+            if (!parameter || defImpl is null) return;
+            if (auto deformable = cast(Deformable)defImpl.getTarget()) {
+                auto deform = cast(DeformationParameterBinding)parameter.getBinding(deformable, "deform");
+                if (deform is null) return;
+                auto kp = parameter.findClosestKeypoint();
+                auto binding = deform.getValue(kp);
+                Vec2Array offs = binding.vertexOffsets.dup;
+                size_t targetLen = defImpl.getOffsets().length;
+                if (offs.length != targetLen) {
+                    Vec2Array resized;
+                    resized.length = targetLen;
+                    size_t n = offs.length < targetLen ? offs.length : targetLen;
+                    foreach (i; 0..n) resized[i] = offs[i];
+                    foreach (i; n..targetLen) resized[i] = vec2(0);
+                    offs = resized;
+                }
+                defImpl.applyOffsets(offs);
+            }
+        }
     }
 
-    void setup(T: MeshGroup)() {
-        fVertImpl.setToolMode(VertexToolMode.Grid);
-        fDefImpl.setToolMode(VertexToolMode.Points);
+    OneTimeDeformScope activeScope = null;
+
+    OneTimeDeformScope ngOneTimeDeformScope() {
+        if (activeScope is null)
+            activeScope = new OneTimeDeformScope();
+        return activeScope;
     }
 
-    void setup(T: GridDeformer)() {
-        fVertImpl.setToolMode(VertexToolMode.Grid);
-        fDefImpl.setToolMode(VertexToolMode.Grid);
+    OneTimeDeformScope ngActiveOneTimeDeformScope() {
+        return activeScope;
     }
 
-    void setup(T: PathDeformer)() {
-        fVertImpl.setToolMode(VertexToolMode.BezierDeform);
-        fDefImpl.setToolMode(VertexToolMode.BezierDeform);
+    void ngDetachOneTimeDeformFilterForSave(Puppet puppet) {
+        if (activeScope)
+            activeScope.detachForSave(puppet);
     }
+
+    void ngRestoreOneTimeDeformFilterAfterSave(Puppet puppet) {
+        if (activeScope)
+            activeScope.restoreAfterSave(puppet);
+    }
+
+    void ngOnOneTimeDeformScopeClosed(ActionStackScopeUnit unit) {
+        if (activeScope)
+            activeScope.onActionScopeClosed();
+    }
+}
+
+shared static this() {
+    incRegisterSaveFunc(&ngDetachOneTimeDeformFilterForSave);
+    ngRegisterPostSaveFunc(&ngRestoreOneTimeDeformFilterAfterSave);
+    ngRegisterActionStackScopeCloseHandler(ActionStackScopeUnit.OneTimeDeform, &ngOnOneTimeDeformScopeClosed);
 }
 
 class OneTimeDeformBase :  NodeSelect {
@@ -118,6 +309,16 @@ class OneTimeDeformBase :  NodeSelect {
 }
 
 class OneTimeDeform(T) : OneTimeDeformBase {
+private:
+    void switchSubTool(SubToolMode next) {
+        if (mode == next) return;
+        auto session = ngOneTimeDeformScope();
+        session.leaveSubTool(mode);
+        mode = next;
+        session.enterSubTool!T(next);
+        appliedMode = next;
+    }
+
 public:
     override
     bool onDragStart(vec2 mousePos, IncMeshEditorOne impl) {
@@ -126,13 +327,13 @@ public:
             return super.onDragStart(mousePos, impl);
         case SubToolMode.Vertex:
             if (acquired)
-                if (auto draggable = cast(Draggable)fVertImpl.getTool())
-                    return draggable.onDragStart(mousePos, fVertImpl);
+                if (auto draggable = cast(Draggable)ngOneTimeDeformScope().vertImpl.getTool())
+                    return draggable.onDragStart(mousePos, ngOneTimeDeformScope().vertImpl);
             break;
         case SubToolMode.Deform:
             if (acquired)
-                if (auto draggable = cast(Draggable)fDefImpl.getTool())
-                    return draggable.onDragStart(mousePos, fDefImpl);
+                if (auto draggable = cast(Draggable)ngOneTimeDeformScope().defImpl.getTool())
+                    return draggable.onDragStart(mousePos, ngOneTimeDeformScope().defImpl);
             break;
         default:
             break;
@@ -147,13 +348,13 @@ public:
             return super.onDragUpdate(mousePos, impl);
         case SubToolMode.Vertex:
             if (acquired)
-                if (auto draggable = cast(Draggable)fVertImpl.getTool())
-                    return draggable.onDragUpdate(mousePos, fVertImpl);
+                if (auto draggable = cast(Draggable)ngOneTimeDeformScope().vertImpl.getTool())
+                    return draggable.onDragUpdate(mousePos, ngOneTimeDeformScope().vertImpl);
             break;
         case SubToolMode.Deform:
             if (acquired)
-                if (auto draggable = cast(Draggable)fDefImpl.getTool())
-                    return draggable.onDragUpdate(mousePos, fDefImpl);
+                if (auto draggable = cast(Draggable)ngOneTimeDeformScope().defImpl.getTool())
+                    return draggable.onDragUpdate(mousePos, ngOneTimeDeformScope().defImpl);
             break;
         default:
             break;
@@ -168,13 +369,13 @@ public:
             return super.onDragEnd(mousePos, impl);
         case SubToolMode.Vertex:
             if (acquired)
-                if (auto draggable = cast(Draggable)fVertImpl.getTool())
-                    return draggable.onDragEnd(mousePos, fVertImpl);
+                if (auto draggable = cast(Draggable)ngOneTimeDeformScope().vertImpl.getTool())
+                    return draggable.onDragEnd(mousePos, ngOneTimeDeformScope().vertImpl);
             break;
         case SubToolMode.Deform:
             if (acquired)
-                if (auto draggable = cast(Draggable)fDefImpl.getTool())
-                    return draggable.onDragEnd(mousePos, fDefImpl);
+                if (auto draggable = cast(Draggable)ngOneTimeDeformScope().defImpl.getTool())
+                    return draggable.onDragEnd(mousePos, ngOneTimeDeformScope().defImpl);
             break;
         default:
             break;
@@ -185,27 +386,32 @@ public:
     override
     void setToolMode(VertexToolMode toolMode, IncMeshEditorOne impl) {
         super.setToolMode(toolMode, impl);
-        acquired = initialize!T(impl.getTarget());
-        if ((cast(T)filter).children.countUntil(impl.getTarget()) < 0) {
-            filter.captureTarget(impl.getTarget());
+        auto session = ngOneTimeDeformScope();
+        session.initialize!T(impl.getTarget());
+        acquired = session.active();
+        if ((cast(T)session.filter).children.countUntil(impl.getTarget()) < 0) {
+            session.filter.captureTarget(impl.getTarget());
         }
         impl.getDeformAction();
-        incActionPushStack();
+        session.begin();
         mode = SubToolMode.Vertex;
+        appliedMode = mode;
     }
 
     override
     void finalizeToolMode(IncMeshEditorOne impl) {
         if (acquired) {
-            incActionPopStack();
+            auto session = ngOneTimeDeformScope();
+            session.leaveSubTool(mode);
+            session.closeActionScope();
 
             // Persist filter deformation into children as an undoable parameter action,
             // then release filter targets and clean up.
             auto param = incArmedParameter();
-            if (filter && param) {
+            if (session.filter && param) {
                 auto kp = param.findClosestKeypoint();
                 ParameterBinding[] bindings;
-                foreach (child; (cast(Node)filter).children) {
+                foreach (child; session.filterNode().children) {
                     if (auto deformable = cast(Deformable)child) {
                         auto b = param.getOrAddBinding(deformable, "deform");
                         if (b !is null)
@@ -219,29 +425,26 @@ public:
                     auto persistAction = new ParameterChangeBindingsValueAction(_("apply deform"), param, bindings, kp.x, kp.y);
 
                     // Apply changes to children, then capture new values
-                    filter.applyDeformToChildren([param], false);
+                    session.filter.applyDeformToChildren([param], false);
                     persistAction.updateNewState();
                     incActionPush(persistAction);
                 } else {
                     // No bindings to persist; still apply to ensure state consistency
-                    filter.applyDeformToChildren([param], false);
+                    session.filter.applyDeformToChildren([param], false);
                 }
 
-                foreach (child; (cast(Node)filter).children) {
-                    filter.releaseTarget(child);
-                }
-                if (fVertImpl)
-                    fVertImpl.removeFilterTarget(impl.getTarget());
-                if (fDefImpl)
-                    fDefImpl.removeFilterTarget(impl.getTarget());
-                if ((cast(Node)filter).children.length == 0) {
-                    (cast(Node)filter).reparent(null, 0);
-                    filter = null;
-                }
+                session.cleanupTarget(impl, true);
                 incViewportNodeDeformNotifyParamValueChanged();
             }
             impl.pushDeformAction();
         }
+    }
+
+    override
+    void abortToolMode(IncMeshEditorOne impl) {
+        auto session = ngActiveOneTimeDeformScope();
+        if (session)
+            session.cleanupTarget(impl, acquired);
     }
 
     override 
@@ -255,14 +458,14 @@ public:
             return super.peek(io, impl);
         case SubToolMode.Vertex:
             if (acquired)
-                vertActionId = fVertImpl.getTool().peek(io, fVertImpl);
+                ngOneTimeDeformScope().vertActionId = ngOneTimeDeformScope().vertImpl.getTool().peek(io, ngOneTimeDeformScope().vertImpl);
             break;
         case SubToolMode.Deform:
             if (acquired) {
                 version(assert) {
-                    assert(fDefImpl !is null, "Deform editor missing on peek");
+                    assert(ngOneTimeDeformScope().defImpl !is null, "Deform editor missing on peek");
                 }
-                defActionId = fDefImpl.getTool().peek(io, fDefImpl);
+                ngOneTimeDeformScope().defActionId = ngOneTimeDeformScope().defImpl.getTool().peek(io, ngOneTimeDeformScope().defImpl);
             }
             break;
         default:
@@ -297,59 +500,10 @@ public:
 
     override bool update(ImGuiIO* io, IncMeshEditorOne impl, int action, out bool changed) {
         incStatusTooltip(_("Switch Mode"), _("TAB"));
-        // Seed deform display from the binding (read-only; no writes).
-        void seedViewFromBinding() {
-            auto parameter = incArmedParameter();
-            if (!parameter) return;
-            if (auto deformable = cast(Deformable)fDefImpl.getTarget()) {
-                auto deform = cast(DeformationParameterBinding)parameter.getBinding(deformable, "deform");
-                if (deform is null) return;
-                auto kp = parameter.findClosestKeypoint();
-                auto binding = deform.getValue(kp);
-                Vec2Array offs = binding.vertexOffsets.dup;
-                size_t targetLen = fDefImpl.getOffsets().length;
-                if (offs.length != targetLen) {
-                    Vec2Array resized;
-                    resized.length = targetLen;
-                    size_t n = offs.length < targetLen ? offs.length : targetLen;
-                    foreach (i; 0..n) resized[i] = offs[i];
-                    foreach (i; n..targetLen) resized[i] = vec2(0);
-                    offs = resized;
-                }
-                fDefImpl.applyOffsets(offs);
-            }
-        }
 
         // Apply side-effects if mode changed externally (e.g., via Undo/Redo of mode action)
         if (appliedMode != mode) {
-            final switch (mode) {
-                case SubToolMode.Deform:
-                    if (acquired) {
-                        fVertImpl.vertexColor = vec4(0, 0.5, 0.5, 1);
-                        fVertImpl.edgeColor   = vec4(0, 0.5, 0.5, 0.5);
-                        fDefImpl.vertexColor = vec4(0, 1, 0, 1);
-                        fDefImpl.edgeColor   = vec4(0, 1, 0, 1);
-                        // Reset tool interaction state on external mode change
-                        fDefImpl.setToolMode(fDefImpl.getToolMode());
-                        fDefImpl.setTarget(cast(T)filter);
-                        fDefImpl.getCleanDeformAction();
-                        seedViewFromBinding();
-                    }
-                    break;
-                case SubToolMode.Vertex:
-                    if (acquired) {
-                        fVertImpl.vertexColor = vec4(0, 1, 1, 1);
-                        fVertImpl.edgeColor   = vec4(0, 1, 1, 1);
-                        fDefImpl.vertexColor = vec4(0, 0.5, 0, 1);
-                        fDefImpl.edgeColor   = vec4(0, 0.5, 0, 0.5);
-                        // Reset tool interaction state on external mode change
-                        fVertImpl.setToolMode(fVertImpl.getToolMode());
-                        fVertImpl.getCleanDeformAction();
-                    }
-                    break;
-                case SubToolMode.Select:
-                    break;
-            }
+            ngOneTimeDeformScope().enterSubTool!T(mode);
             appliedMode = mode;
         }
 
@@ -357,7 +511,8 @@ public:
             // Group persistence + mode change into one undo step
             incActionPushGroup();
             // Capture per-target old/new modes to keep UI mode flips in history.
-            Node[] targets = fDefImpl ? fDefImpl.getFilterTargets() : (fVertImpl ? fVertImpl.getFilterTargets() : null);
+            auto session = ngOneTimeDeformScope();
+            Node[] targets = session.defImpl ? session.defImpl.getFilterTargets() : (session.vertImpl ? session.vertImpl.getFilterTargets() : null);
             SubToolMode[] oldModes;
             SubToolMode[] newModes;
             if (targets && targets.length > 0) {
@@ -375,42 +530,16 @@ public:
                 }
             }
 
-            switch (mode) {
+            final switch (mode) {
             case SubToolMode.Select:
-                mode = SubToolMode.Vertex;
+                switchSubTool(SubToolMode.Vertex);
                 break;
             case SubToolMode.Vertex:
-                if (acquired) {
-                    mode = SubToolMode.Deform;
-                    fVertImpl.vertexColor = vec4(0, 0.5, 0.5, 1);
-                    fVertImpl.edgeColor   = vec4(0, 0.5, 0.5, 0.5);
-                    fDefImpl.vertexColor = vec4(0, 1, 0, 1);
-                    fDefImpl.edgeColor   = vec4(0, 1, 0, 1);
-                    fVertImpl.pushDeformAction();
-                    fVertImpl.applyToTarget();
-                    if (auto deformable = cast(Deformable)filter) {
-                        auto parameter = incArmedParameter();
-                        parameter.update();
-                    }
-                    fDefImpl.setTarget(cast(T)filter);
-                    // Reset deform editor baseline; do not push here
-                    fDefImpl.getCleanDeformAction();
-                    // Seed the view from the current binding
-                    seedViewFromBinding();
-                }
+                switchSubTool(SubToolMode.Deform);
                 break;
             case SubToolMode.Deform:
-                if (acquired) {
-                    fVertImpl.vertexColor = vec4(0, 1, 1, 1);
-                    fVertImpl.edgeColor   = vec4(0, 1, 1, 1);
-                    fDefImpl.vertexColor = vec4(0, 0.5, 0, 1);
-                    fDefImpl.edgeColor   = vec4(0, 0.5, 0, 0.5);
-                    fDefImpl.pushDeformAction();
-                    fVertImpl.getCleanDeformAction();
-                    mode = SubToolMode.Vertex;
-                }
+                switchSubTool(SubToolMode.Vertex);
                 break;
-            default:
             }
             // Push mode change action after switching internal state, so redo/undo reflect UI mode.
             import nijigenerate.actions.mesheditor : SubToolModeChangeAction;
@@ -428,29 +557,31 @@ public:
             return super.update(io, impl, action, changed);
         case SubToolMode.Vertex:
             if (acquired) {
-                bool result = fVertImpl.getTool().update(io, fVertImpl, vertActionId, changed);
+                auto session = ngOneTimeDeformScope();
+                bool result = session.vertImpl.getTool().update(io, session.vertImpl, session.vertActionId, changed);
                 // When vertex count or map updates, transfer deformation to the current shape accurately
-                if (fVertImpl.vertexMapDirty) {
-                    fVertImpl.applyToTarget();
+                if (session.vertImpl.vertexMapDirty) {
+                    session.vertImpl.applyToTarget();
                     auto parameter = incArmedParameter();
                     if (parameter) parameter.update();
-                    fVertImpl.vertexMapDirty = false;
+                    session.vertImpl.vertexMapDirty = false;
                 }
                 return result;
             }
             break;
         case SubToolMode.Deform:
             if (acquired) {
-                bool result = fDefImpl.getTool().update(io, fDefImpl, defActionId, changed);
+                auto session = ngOneTimeDeformScope();
+                bool result = session.defImpl.getTool().update(io, session.defImpl, session.defActionId, changed);
                 // 1-frame delayed write to binding: apply last frame's offsets now
                 if (result) {
                     auto parameter = incArmedParameter();
                     if (parameter) {
-                        auto deform = cast(DeformationParameterBinding)parameter.getOrAddBinding(cast(T)filter, "deform");
+                        auto deform = cast(DeformationParameterBinding)parameter.getOrAddBinding(cast(T)session.filter, "deform");
                         if (deform !is null)
-                            deform.update(parameter.findClosestKeypoint(), fDefImpl.getOffsets());
+                            deform.update(parameter.findClosestKeypoint(), session.defImpl.getOffsets());
                     }
-                    fDefImpl.markActionDirty();
+                    session.defImpl.markActionDirty();
                 }
                 return result;
             }
@@ -466,16 +597,17 @@ public:
             super.draw(camera, impl);
 
         if (acquired) {
+            auto session = ngOneTimeDeformScope();
             if (mode == SubToolMode.Vertex) {
-//                fDefImpl.draw(camera);
-//                fDefImpl.getTool().draw(camera, fDefImpl);
-                fVertImpl.draw(camera);
-                fVertImpl.getTool().draw(camera, fVertImpl);
+//                session.defImpl.draw(camera);
+//                session.defImpl.getTool().draw(camera, session.defImpl);
+                session.vertImpl.draw(camera);
+                session.vertImpl.getTool().draw(camera, session.vertImpl);
             } else {
-                fVertImpl.draw(camera);
-                fVertImpl.getTool().draw(camera, fVertImpl);
-                fDefImpl.draw(camera);
-                fDefImpl.getTool().draw(camera, fDefImpl);
+                session.vertImpl.draw(camera);
+                session.vertImpl.getTool().draw(camera, session.vertImpl);
+                session.defImpl.draw(camera);
+                session.defImpl.getTool().draw(camera, session.defImpl);
             }
         }
 
@@ -514,13 +646,14 @@ IncMeshEditorOne ngGetArmedParameterEditorFor(Node node) {
             return gFilterEditors[f];
     }
     // Map original deformable target to the current deform editor when filtered
-    if (filter !is null) {
-        foreach (child; (cast(Node)filter).children) {
+    auto session = ngActiveOneTimeDeformScope();
+    if (session !is null && session.filter !is null) {
+        foreach (child; session.filterNode().children) {
             if (child is node) {
-                if (cast(NodeFilter)filter in gFilterEditors)
-                    return gFilterEditors[cast(NodeFilter)filter];
+                if (session.filter in gFilterEditors)
+                    return gFilterEditors[session.filter];
                 else
-                    return fDefImpl;
+                    return session.defImpl;
             }
         }
     }
@@ -530,5 +663,6 @@ IncMeshEditorOne ngGetArmedParameterEditorFor(Node node) {
 // Expose current active NodeFilter for OneTimeDeform to allow actions to
 // resolve stale filter targets to the current instance during Undo/Redo.
 NodeFilter ngCurrentNodeFilter() {
-    return cast(NodeFilter)filter;
+    auto session = ngActiveOneTimeDeformScope();
+    return session ? session.filter : null;
 }

--- a/source/nijigenerate/viewport/common/mesheditor/tools/onetimedeform.d
+++ b/source/nijigenerate/viewport/common/mesheditor/tools/onetimedeform.d
@@ -426,14 +426,14 @@ private {
             case SubToolMode.Vertex:
                 vertImpl.vertexColor = vec4(0, 1, 1, 1);
                 vertImpl.edgeColor   = vec4(0, 1, 1, 1);
-                defImpl.vertexColor = vec4(0, 0.5, 0, 1);
-                defImpl.edgeColor   = vec4(0, 0.5, 0, 0.5);
+                defImpl.vertexColor = vec4(0, 0.6, 0, 1);
+                defImpl.edgeColor   = vec4(0, 0.6, 0, 1);
                 resetCurrentTool(vertImpl);
                 vertImpl.getCleanDeformAction();
                 break;
             case SubToolMode.Deform:
-                vertImpl.vertexColor = vec4(0, 0.5, 0.5, 1);
-                vertImpl.edgeColor   = vec4(0, 0.5, 0.5, 0.5);
+                vertImpl.vertexColor = vec4(0, 0.6, 0.6, 1);
+                vertImpl.edgeColor   = vec4(0, 0.6, 0.6, 1);
                 defImpl.vertexColor = vec4(0, 1, 0, 1);
                 defImpl.edgeColor   = vec4(0, 1, 0, 1);
                 resetCurrentTool(defImpl);
@@ -1050,8 +1050,8 @@ public:
         if (acquired) {
             auto session = ngOneTimeDeformScope();
             if (mode == SubToolMode.Vertex) {
-//                session.defImpl.draw(camera);
-//                session.defImpl.getTool().draw(camera, session.defImpl);
+                session.defImpl.draw(camera);
+                session.defImpl.getTool().draw(camera, session.defImpl);
                 session.vertImpl.draw(camera);
                 session.vertImpl.getTool().draw(camera, session.vertImpl);
             } else {

--- a/source/nijigenerate/viewport/common/mesheditor/tools/onetimedeform.d
+++ b/source/nijigenerate/viewport/common/mesheditor/tools/onetimedeform.d
@@ -23,7 +23,6 @@ import nijilive.core.nodes.deformer.grid : GridDeformer;
 import nijigenerate.core.dbg;
 import bindbc.opengl;
 import bindbc.imgui;
-import std.stdio : writefln;
 import std.algorithm;
 import std.array;
 import std.math : isFinite;
@@ -35,10 +34,6 @@ enum SubToolMode {
 }
 
 private {
-    void oneTimeDeformLog(Args...)(string fmt, Args args) {
-        writefln("[OneTimeDeform] " ~ fmt, args);
-    }
-
     // Map active NodeFilter -> its deform editor to resolve editors during Undo/Redo reliably
     IncMeshEditorOne[NodeFilter] gFilterEditors;
 
@@ -167,11 +162,6 @@ private {
             if (auto gridTool = cast(GridTool)vertImpl.getTool())
                 gridTool.resetVirtualMeshAsEmpty(vertImpl);
             defImpl.setToolMode(VertexToolMode.Points);
-            oneTimeDeformLog("setup GridDeformer: filter=%s vertTool=%s defTool=%s vertVertices=%s defOffsets=%s",
-                filterNode() ? filterNode().name : "(null)",
-                vertImpl.getToolMode(), defImpl.getToolMode(),
-                (cast(IncMeshEditorOneDeformable)vertImpl) ? (cast(IncMeshEditorOneDeformable)vertImpl).vertices.length : 0,
-                defImpl.getOffsets().length);
         }
 
         void setup(T: PathDeformer)() {
@@ -259,15 +249,7 @@ private {
 
             bool applied = false;
             if (auto gridTool = cast(GridTool)vertImpl.getTool()) {
-                oneTimeDeformLog("applyVertexToolToFilter: before target=%s dirty=%s vertices=%s",
-                    vertImpl.getTarget() ? vertImpl.getTarget().name : "(null)",
-                    vertImpl.vertexMapDirty,
-                    (cast(IncMeshEditorOneDeformable)vertImpl) ? (cast(IncMeshEditorOneDeformable)vertImpl).vertices.length : 0);
                 applied = gridTool.applyVirtualMeshToTarget(vertImpl);
-                oneTimeDeformLog("applyVertexToolToFilter: grid applied=%s targetVertices=%s targetDeformation=%s",
-                    applied,
-                    (cast(Deformable)vertImpl.getTarget()) ? (cast(Deformable)vertImpl.getTarget()).vertices.length : 0,
-                    (cast(Deformable)vertImpl.getTarget()) ? (cast(Deformable)vertImpl.getTarget()).deformation.length : 0);
                 if (!applied)
                     return false;
             } else {
@@ -412,12 +394,6 @@ private {
 
         void enterSubTool(T)(SubToolMode next) {
             if (!active()) return;
-            oneTimeDeformLog("enterSubTool: %s -> %s filter=%s filterVertices=%s filterDeformation=%s defOffsetsBefore=%s",
-                currentMode, next,
-                filterNode() ? filterNode().name : "(null)",
-                (cast(Deformable)filter) ? (cast(Deformable)filter).vertices.length : 0,
-                (cast(Deformable)filter) ? (cast(Deformable)filter).deformation.length : 0,
-                defImpl ? defImpl.getOffsets().length : 0);
             currentMode = next;
             invalidatePeekCache();
             final switch (next) {
@@ -440,11 +416,6 @@ private {
                 defImpl.setTarget(cast(T)filter);
                 defImpl.getCleanDeformAction();
                 seedViewFromBinding();
-                oneTimeDeformLog("enterSubTool Deform ready: defTarget=%s offsets=%s selected=%s vtxAtMouse=%s",
-                    defImpl.getTarget() ? defImpl.getTarget().name : "(null)",
-                    defImpl.getOffsets().length,
-                    defImpl.selected.length,
-                    defImpl.vtxAtMouse);
                 break;
             }
         }
@@ -921,11 +892,6 @@ public:
             if (sessionForAction.switchModeConsumed)
                 return false;
             sessionForAction.switchModeConsumed = true;
-            oneTimeDeformLog("switch action start: outerTarget=%s mode=%s currentMode=%s acquired=%s",
-                impl.getTarget() ? impl.getTarget().name : "(null)",
-                mode,
-                sessionForAction.currentMode,
-                acquired);
             // Group persistence + mode change into one undo step
             incActionPushGroup();
             // Capture per-target old/new modes to keep UI mode flips in history.
@@ -961,11 +927,6 @@ public:
                 break;
             }
             switchSubTool(nextMode);
-            oneTimeDeformLog("switch action applied: nextMode=%s currentMode=%s filterVertices=%s defOffsets=%s",
-                nextMode,
-                session.currentMode,
-                (cast(Deformable)session.filter) ? (cast(Deformable)session.filter).vertices.length : 0,
-                session.defImpl ? session.defImpl.getOffsets().length : 0);
             if (targets && targets.length > 0 && newModes.length == targets.length) {
                 foreach (i, t; targets) {
                     auto ed = ngGetEditorFor(t);
@@ -1008,18 +969,6 @@ public:
                 bool result = updateSharedSubTool(session, mode, action, (out bool localChanged) {
                     return session.defImpl.getTool().update(io, session.defImpl, action, localChanged);
                 }, changed);
-                if (action != SelectActionID.None || changed) {
-                    oneTimeDeformLog("update Deform: target=%s action=%s changed=%s result=%s defOffsets=%s selected=%s vtxAtMouse=%s mouse=(%s,%s)",
-                        impl.getTarget() ? impl.getTarget().name : "(null)",
-                        action,
-                        changed,
-                        result,
-                        session.defImpl ? session.defImpl.getOffsets().length : 0,
-                        session.defImpl ? session.defImpl.selected.length : 0,
-                        session.defImpl ? session.defImpl.vtxAtMouse : ulong.max,
-                        session.defImpl ? session.defImpl.mousePos.x : 0,
-                        session.defImpl ? session.defImpl.mousePos.y : 0);
-                }
                 if (changed) {
                     auto parameter = incArmedParameter();
                     if (parameter) {
@@ -1074,7 +1023,7 @@ class ToolInfoImpl(T: OneTimeDeform!GridDeformer) : ToolInfoBase!(T) {
     }
     override bool canUse(bool deformOnly, Node[] targets) { return deformOnly; }
     override VertexToolMode mode() { return VertexToolMode.AltGridDeform; };
-    override string icon() { return "";}
+    override string icon() { return "";}
     override string description() { return _("Grid deformation");}
 }
 
@@ -1087,7 +1036,7 @@ class ToolInfoImpl(T: OneTimeDeform!PathDeformer) : ToolInfoBase!(T) {
     }
     override bool canUse(bool deformOnly, Node[] targets) { return deformOnly; }
     override VertexToolMode mode() { return VertexToolMode.AltBezierDeform; };
-    override string icon() { return "";}
+    override string icon() { return "";}
     override string description() { return _("Path deformation");}
 }
 

--- a/source/nijigenerate/viewport/common/mesheditor/tools/package.d
+++ b/source/nijigenerate/viewport/common/mesheditor/tools/package.d
@@ -30,8 +30,8 @@ ToolInfo[] incGetToolInfo() {
         infoList ~= new ToolInfoImpl!(LassoTool);
         infoList ~= new ToolInfoImpl!(EdgeCutterTool);
         infoList ~= new ToolInfoImpl!(BezierDeformTool);
-//        infoList ~= new ToolInfoImpl!(OneTimeDeform!MeshGroup); // Disabled tool temporary
-//        infoList ~= new ToolInfoImpl!(OneTimeDeform!PathDeformer); // Disabled tool temporary
+        infoList ~= new ToolInfoImpl!(OneTimeDeform!MeshGroup);
+        infoList ~= new ToolInfoImpl!(OneTimeDeform!PathDeformer);
     }
     return infoList;
 }

--- a/source/nijigenerate/viewport/common/mesheditor/tools/package.d
+++ b/source/nijigenerate/viewport/common/mesheditor/tools/package.d
@@ -30,7 +30,7 @@ ToolInfo[] incGetToolInfo() {
         infoList ~= new ToolInfoImpl!(LassoTool);
         infoList ~= new ToolInfoImpl!(EdgeCutterTool);
         infoList ~= new ToolInfoImpl!(BezierDeformTool);
-        infoList ~= new ToolInfoImpl!(OneTimeDeform!MeshGroup);
+        infoList ~= new ToolInfoImpl!(OneTimeDeform!GridDeformer);
         infoList ~= new ToolInfoImpl!(OneTimeDeform!PathDeformer);
     }
     return infoList;

--- a/source/nijigenerate/viewport/common/mesheditor/tools/pathdeform.d
+++ b/source/nijigenerate/viewport/common/mesheditor/tools/pathdeform.d
@@ -393,9 +393,9 @@ class ToolInfoImpl(T: PathDeformTool) : ToolInfoBase!(T) {
 
     override
     bool viewportTools(bool deformOnly, VertexToolMode toolMode, IncMeshEditorOne[Node] editors) {
-        if (deformOnly && editors.keys.all!((k) => cast(Drawable)k !is null || cast(Deformable)k is null )) {
-            return super.viewportTools(deformOnly, toolMode, editors);
-        }
+        // Hidden while keeping the tool registered for existing editor state.
+        // Removing it from ToolInfo breaks mode lookup when an existing editor
+        // is still in PathDeform mode.
         return false;
     }
     override bool canUse(bool deformOnly, Node[] targets) {

--- a/source/nijigenerate/viewport/depth/mesheditor/editor.d
+++ b/source/nijigenerate/viewport/depth/mesheditor/editor.d
@@ -41,7 +41,7 @@ private:
     float dragStartMouseY;
     bool draggingOperation;
     DepthTextureMeshRenderer renderer;
-    bool stackPushed;
+    ActionStackScope actionScope;
 
     bool editable(Node node) {
         auto ok = cast(GridDeformer)node !is null;
@@ -86,8 +86,7 @@ private:
 public:
     this() {
         renderer = new DepthTextureMeshRenderer();
-        incActionPushStack();
-        stackPushed = true;
+        actionScope = ngOpenActionStackScope(ActionStackScopeUnit.DepthEdit);
     }
 
     ~this() {
@@ -95,15 +94,16 @@ public:
     }
 
     void dispose() {
+        closeStack();
         foreach (editor; editors.byValue) editor.dispose();
         editors.clear();
         operations.clear();
     }
 
     void closeStack() {
-        if (stackPushed) {
-            incActionPopStack();
-            stackPushed = false;
+        if (actionScope) {
+            actionScope.close();
+            actionScope = null;
         }
     }
 

--- a/source/nijigenerate/viewport/model/mesheditor/editor.d
+++ b/source/nijigenerate/viewport/model/mesheditor/editor.d
@@ -123,6 +123,11 @@ public:
                 newEditors[t] = subEditor;
             }
         }
+        foreach (node, editor; editors) {
+            if (node !in newEditors) {
+                editor.abortToolMode();
+            }
+        }
         editors = newEditors;
 //        adjustToolModeForSelection();
     }

--- a/source/nijigenerate/viewport/vertex/mesheditor/deformable.d
+++ b/source/nijigenerate/viewport/vertex/mesheditor/deformable.d
@@ -328,7 +328,7 @@ public:
                 auto curve = deformable.createCurve(Vec2Array(vertsAoS));
                 drawLines(curve, trans, edgeColor);
             } else if (auto grid = cast(GridDeformer)target) {
-                auto baseVerts = grid.vertices;
+                auto baseVerts = Vec2Array(vertices.map!(v => v.position).array);
                 if (baseVerts.length >= 4) {
                     auto baseVertsAoS = baseVerts.toArray();
                     auto xs = baseVertsAoS.map!(v => v.x).array;
@@ -341,24 +341,20 @@ public:
                     size_t rows = ys.length;
                     if (cols >= 2 && rows >= 2 && cols * rows == baseVerts.length) {
                         Vec3Array lines;
-                        bool haveDeform = grid.deformation.length == baseVerts.length;
                         foreach (y; 0 .. rows) {
                             foreach (x; 0 .. cols) {
                                 size_t idx = y * cols + x;
                                 vec2 startPos = baseVertsAoS[idx];
-                                if (haveDeform) startPos += grid.deformation[idx];
                                 auto start = vec3(startPos, 0);
                                 if (x + 1 < cols) {
                                     size_t nextIdx = idx + 1;
                                     vec2 rightPos = baseVertsAoS[nextIdx];
-                                    if (haveDeform) rightPos += grid.deformation[nextIdx];
                                     lines ~= start;
                                     lines ~= vec3(rightPos, 0);
                                 }
                                 if (y + 1 < rows) {
                                     size_t nextIdx = idx + cols;
                                     vec2 downPos = baseVertsAoS[nextIdx];
-                                    if (haveDeform) downPos += grid.deformation[nextIdx];
                                     lines ~= start;
                                     lines ~= vec3(downPos, 0);
                                 }

--- a/source/nijigenerate/viewport/vertex/mesheditor/editor.d
+++ b/source/nijigenerate/viewport/vertex/mesheditor/editor.d
@@ -31,6 +31,8 @@ import std.string;
 
 class VertexMeshEditor : IncMeshEditor {
 private:
+    ActionStackScope actionScope;
+
     void adjustToolModeForSelection() {
         bool anyGrid = false;
         bool anyPath = false;
@@ -72,6 +74,18 @@ private:
 public:
     this() {
         super(false);
+        actionScope = ngOpenActionStackScope(ActionStackScopeUnit.VertexEdit);
+    }
+
+    ~this() {
+        closeScope();
+    }
+
+    void closeScope() {
+        if (actionScope) {
+            actionScope.close();
+            actionScope = null;
+        }
     }
 
     override
@@ -81,7 +95,6 @@ public:
         IncMeshEditorOne subEditor;
 
         if (auto drawable = cast(Drawable)target) {
-            incActionPushStack();
             subEditor = new IncMeshEditorOneFor!(Drawable, EditMode.VertexEdit)();
             float[][] axes;
             if (drawable.getMesh().vertices.isGrid(axes)) {
@@ -89,7 +102,6 @@ public:
                 toolMode           = VertexToolMode.Grid;
             }
         } else if (auto deformable = cast(Deformable)target) {
-            incActionPushStack();
             subEditor = new IncMeshEditorOneFor!(Deformable, EditMode.VertexEdit)();
             if (cast(PathDeformer)deformable) {
                 subEditor.toolMode = VertexToolMode.BezierDeform;
@@ -115,10 +127,8 @@ public:
             } else {
                 IncMeshEditorOne subEditor = null;
                 if (auto drawable = cast(Drawable)t) {
-                    incActionPushStack();
                     subEditor = new IncMeshEditorOneFor!(Drawable, EditMode.VertexEdit)();
                 } else if (auto deformable = cast(Deformable)t) {
-                    incActionPushStack();
                     subEditor = new IncMeshEditorOneFor!(Deformable, EditMode.VertexEdit)();
                     if (cast(GridDeformer)deformable) {
                         subEditor.toolMode = VertexToolMode.Grid;
@@ -127,7 +137,6 @@ public:
                         subEditor.toolMode = VertexToolMode.BezierDeform;
                     }
                 } else {
-                    incActionPushStack();
                     subEditor = new IncMeshEditorOneFor!Node(deformOnly);
                 }
                 subEditor.setTarget(t);
@@ -135,6 +144,11 @@ public:
                 subEditor.mirrorVert  = mirrorVert;
                 subEditor.previewTriangulate = previewTriangulate;
                 newEditors[t] = subEditor;
+            }
+        }
+        foreach (node, editor; editors) {
+            if (node !in newEditors) {
+                editor.abortToolMode();
             }
         }
         editors = newEditors;

--- a/source/nijigenerate/viewport/vertex/package.d
+++ b/source/nijigenerate/viewport/vertex/package.d
@@ -329,7 +329,8 @@ public:
                 } else {
                     incMeshEditClear();
                 }
-                incActionPopStack();
+                if (auto vertexEditor = cast(VertexMeshEditor)editor)
+                    vertexEditor.closeScope();
                 incSetEditMode(EditMode.ModelEdit);
                 foreach (d; target) {
                     incAddSelectNode(d);
@@ -346,7 +347,9 @@ public:
     }
 
     override
-    void withdraw() { 
+    void withdraw() {
+        if (auto vertexEditor = cast(VertexMeshEditor)editor)
+            vertexEditor.closeScope();
         editor = null;
     };
 
@@ -409,7 +412,8 @@ public:
             }
         }
 
-        incActionPopStack();
+        if (auto vertexEditor = cast(VertexMeshEditor)editor)
+            vertexEditor.closeScope();
         // Apply to target
         editor.applyToTarget();
 


### PR DESCRIPTION
## Summary

- Rework OneTimeDeform as temporary GridDeformer / PathDeformer based editing tools
- Apply OneTimeDeform results so the final deformation better matches the live editing preview
- Manage undo/redo escape behavior through ActionStackScope across Vertex, Deform, DepthEdit, and OneTimeDeform
- Synchronize temporary mesh and deformation state when switching OneTimeDeform subtools
- Include active OneTimeDeform edits when saving a copied model
- Hide the legacy PathDeform tool from the toolbar while keeping it registered for compatibility
- Update OneTimeDeform Path/Grid icons and inactive overlay colors
- Remove temporary debug logging

## Details

- Added ActionStackScope to close edit scopes by defined units instead of relying on separate Mode / Editor / Subtool handling
- Fixed initial Point editing and virtual mesh synchronization issues in the OneTimeDeform GridDeformer path
- Fixed extra Deformation entries being created during GridDeformer based OneTimeDeform editing
- Fixed GridDeformer Vertex mode drawing to use the edit base vertices instead of already-deformed vertices
- Applied the current OneTimeDeform subtool state to model copies during save
- Kept the legacy PathDeform ToolInfo registered to preserve existing editor state, but disabled its toolbar button
