### PR TITLE
fix: avoid silent crash on fatal errors

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -189,8 +189,8 @@ int main(string[] args)
         incFinalize();
     } catch(Throwable ex) {
         debug {
+            crashdump(ex);
             version(Windows) {
-                crashdump(ex);
             } else {
                 throw ex;
             }

--- a/source/app.d
+++ b/source/app.d
@@ -65,6 +65,13 @@ version(Windows) {
 
 int main(string[] args)
 {
+    if (args.length >= 3 && args[1] == "--crash-notify") {
+        incSettingsLoad();
+        incLocaleInitFromSettings();
+        notifyCrashUser(args[2]);
+        return 0;
+    }
+
     try {
         version(RegressionSmoke) {
             auto regressionSmoke = ngParseRegressionSmokeOptions(args);
@@ -82,14 +89,7 @@ int main(string[] args)
         }
         scope(exit) stopBackgroundServices();
         incSettingsLoad();
-        incLocaleInit();
-        if (incSettingsCanGet("lang")) {
-            string lang = incSettingsGet!string("lang");
-            auto entry = incLocaleGetEntryFor(lang);
-            if (entry !is null) {
-                i18nLoadLanguage(entry.file);
-            }
-        }
+        incLocaleInitFromSettings();
 
         inSetUpdateBounds(true);
 

--- a/source/nijigenerate/core/i18n.d
+++ b/source/nijigenerate/core/i18n.d
@@ -106,6 +106,16 @@ void incLocaleInit() {
     markDups(localeFiles);
 }
 
+void incLocaleInitFromSettings() {
+    incLocaleInit();
+    if (incSettingsCanGet("lang")) {
+        string lang = incSettingsGet!string("lang");
+        auto entry = incLocaleGetEntryFor(lang);
+        if (entry !is null)
+            i18nLoadLanguage(entry.file);
+    }
+}
+
 bool compareEntries(TLEntry a, TLEntry b) {
     int cmp = icmp(a.humanName, b.humanName);
     if (cmp == 0) {

--- a/source/nijigenerate/utils/crashdump.d
+++ b/source/nijigenerate/utils/crashdump.d
@@ -33,7 +33,7 @@ version(Posix) {
     import core.sys.posix.signal : SA_ONSTACK, SA_RESETHAND, SA_SIGINFO, SIGSEGV, SIGSTKSZ,
         sigaction, sigaction_t, sigaltstack, sigemptyset, siginfo_t, stack_t;
     import core.sys.posix.sys.types : mode_t;
-    import core.sys.posix.unistd : _exit, close, getpid, write;
+    import core.sys.posix.unistd : _exit, close, fork, getpid, write;
 
     version(OSX) {
         import core.sys.darwin.execinfo : backtrace, backtrace_symbols_fd;
@@ -72,6 +72,28 @@ version(Windows) {
 
     private void ShowMessageBox(string message, string title) {
         MessageBoxW(null, toUTF16z(message), toUTF16z(title), 0);
+    }
+}
+
+version(Posix) {
+    private void ShowMessageBox(string message, string title) {
+        import tinyfiledialogs;
+        import std.string : toStringz;
+        import std.stdio : writeln;
+        // Native dialog (Cocoa / GTK / Zenity). Do not use SDL/ImGui here; the GL
+        // frame may be broken after an exception and SDL message boxes often fail silently.
+        tinyfd_messageBox(toStringz(title), toStringz(message), "ok", "error", 1);
+        writeln(title);
+        writeln(message);
+    }
+
+    private void ShowMessageBox(string dumpPath) {
+        import std.format : format;
+        ShowMessageBox(
+            _("The application has unexpectedly crashed.\n\nIf autosave is enabled, open File → Recent → Autosaves to recover your work.\n\nA crash report was written to:\n%s\n\nPlease attach it when filing an issue:\nhttps://github.com/nijigenerate/nijigenerate/issues").format(
+                dumpPath.length ? dumpPath : getCrashDumpDir()),
+            _("nijigenerate Crashdump")
+        );
     }
 }
 
@@ -130,7 +152,7 @@ version(Posix) {
         writeAll(fd, buf[pos .. $]);
     }
 
-    extern(C) private void nativeCrashSignalHandler(int sig, siginfo_t* info, void* context) nothrow @nogc {
+    extern(C) private void nativeCrashSignalHandler(int sig, siginfo_t* info, void* context) {
         if (nativeCrashHandlerActive) {
             _exit(128 + sig);
         }
@@ -161,6 +183,17 @@ version(Posix) {
             writeAll(fd, "\n\nSymbolication hint:\n");
             writeAll(fd, "  atos -o <nijigenerate-binary> -arch arm64 <address>\n");
             close(fd);
+        }
+
+        // crashdump() is not reached on SIGSEGV; fork a child to notify the user.
+        auto pid = fork();
+        if (pid == 0) {
+            try {
+                string dumpPath = nativeCrashDumpPathLen > 0
+                    ? nativeCrashDumpPath[0 .. nativeCrashDumpPathLen].idup : "";
+                notifyCrashUser(dumpPath);
+            } catch (Throwable) {}
+            _exit(0);
         }
 
         // SA_RESETHAND has already restored the default handler; re-raise so
@@ -227,8 +260,9 @@ string writeCrashDump(T...)(string filename, Throwable throwable, T state) {
 
 void crashdump(T...)(Throwable throwable, T state) {
     // Write crash dump to disk
+    string dumpPath;
     try {
-        writeCrashDump("nijigenerate-crashdump", throwable, state);
+        dumpPath = writeCrashDump("nijigenerate-crashdump", throwable, state);
     } catch (Exception ex) {
         version (Windows) {
         } else{
@@ -238,13 +272,19 @@ void crashdump(T...)(Throwable throwable, T state) {
     }
 
     // Use appropriate system method to notify user where crash dump is.
+    notifyCrashUser(dumpPath);
+}
+
+void notifyCrashUser(string dumpPath) {
     version(OSX) {
         import std.stdio;
         writeln(_("\n\n\n===   nijigenerate has crashed   ===\nPlease send us the nijigenerate-crashdump.txt file in ~/Library/Logs\nAttach the file as a git issue @ https://github.com/nijigenerate/nijigenerate/issues"));
+        ShowMessageBox(dumpPath);
     }
     else version(linux) {
         import std.stdio;
         writeln(_("\n\n\n===   nijigenerate has crashed   ===\nPlease send us the nijigenerate-crashdump.txt file in your log directory, XDG_STATE_HOME. For Flatpak, this is in ~/.var/app/nijigenerate.nijigenerate.\nAttach the file as a git issue @ https://github.com/nijigenerate/nijigenerate/issues"));
+        ShowMessageBox(dumpPath);
     }
     else version(Windows) ShowMessageBox(
         _("The application has unexpectedly crashed\nPlease send the developers the nijigenerate-crashdump.txt which has been put on your desktop\nVia https://github.com/nijigenerate/nijigenerate/issues"),

--- a/source/nijigenerate/utils/crashdump.d
+++ b/source/nijigenerate/utils/crashdump.d
@@ -76,24 +76,16 @@ version(Windows) {
 }
 
 version(Posix) {
-    private void ShowMessageBox(string message, string title) {
+    private void ShowMessageBox(string dumpPath) {
         import tinyfiledialogs;
+        import std.format : format;
         import std.string : toStringz;
         import std.stdio : writeln;
-        // Native dialog (Cocoa / GTK / Zenity). Do not use SDL/ImGui here; the GL
-        // frame may be broken after an exception and SDL message boxes often fail silently.
-        tinyfd_messageBox(toStringz(title), toStringz(message), "ok", "error", 1);
-        writeln(title);
-        writeln(message);
-    }
+        auto title = __("nijigenerate Crashdump");
+        auto message = _("The application has unexpectedly crashed.\n\nIf autosave is enabled, open File → Recent → Autosaves to recover your work.\n\nA crash report was written to:\n%s\n\nPlease attach it when filing an issue:\nhttps://github.com/nijigenerate/nijigenerate/issues").format(
+            dumpPath.length ? dumpPath : getCrashDumpDir());
 
-    private void ShowMessageBox(string dumpPath) {
-        import std.format : format;
-        ShowMessageBox(
-            _("The application has unexpectedly crashed.\n\nIf autosave is enabled, open File → Recent → Autosaves to recover your work.\n\nA crash report was written to:\n%s\n\nPlease attach it when filing an issue:\nhttps://github.com/nijigenerate/nijigenerate/issues").format(
-                dumpPath.length ? dumpPath : getCrashDumpDir()),
-            _("nijigenerate Crashdump")
-        );
+        tinyfd_messageBox(title, message.toStringz, "ok", "error", 1);
     }
 }
 

--- a/source/nijigenerate/utils/crashdump.d
+++ b/source/nijigenerate/utils/crashdump.d
@@ -6,7 +6,7 @@
     Authors: Luna Nielsen
 */
 module nijigenerate.utils.crashdump;
-import std.file : write;
+import std.file : write, thisExePath;
 //import std.stdio;
 import std.path;
 import std.process : environment;
@@ -33,7 +33,7 @@ version(Posix) {
     import core.sys.posix.signal : SA_ONSTACK, SA_RESETHAND, SA_SIGINFO, SIGSEGV, SIGSTKSZ,
         sigaction, sigaction_t, sigaltstack, sigemptyset, siginfo_t, stack_t;
     import core.sys.posix.sys.types : mode_t;
-    import core.sys.posix.unistd : _exit, close, fork, getpid, write;
+    import core.sys.posix.unistd : _exit, close, execv, fork, getpid, write;
 
     version(OSX) {
         import core.sys.darwin.execinfo : backtrace, backtrace_symbols_fd;
@@ -111,6 +111,8 @@ version(Posix) {
     enum int nativeBacktraceMaxFrames = 128;
     __gshared char[nativeCrashPathMax] nativeCrashDumpPath;
     __gshared size_t nativeCrashDumpPathLen;
+    __gshared char[nativeCrashPathMax] nativeCrashExePath;
+    __gshared size_t nativeCrashExePathLen;
     __gshared int nativeCrashHandlerActive;
     void* nativeSignalStack;
 
@@ -173,26 +175,22 @@ version(Posix) {
         }
     }
 
-    private void notifyNativeCrashUserAfterSignal() {
-        // crashdump() is not reached on SIGSEGV; fork a child to notify the user.
-        auto pid = fork();
-        if (pid == 0) {
-            try {
-                string dumpPath = nativeCrashDumpPathLen > 0
-                    ? nativeCrashDumpPath[0 .. nativeCrashDumpPathLen].idup : "";
-                notifyCrashUser(dumpPath);
-            } catch (Throwable) {}
-            _exit(0);
-        }
+    private void notifyNativeCrashUserAfterSignal() nothrow @nogc {
+        if (nativeCrashExePathLen == 0) return;
+        if (fork() != 0) return;
+        const(char)*[4] argv = [
+            nativeCrashExePath.ptr, "--crash-notify", nativeCrashDumpPath.ptr, null,
+        ];
+        execv(nativeCrashExePath.ptr, cast(char**)argv.ptr);
+        _exit(127);
     }
 
-    extern(C) private void nativeCrashSignalHandler(int sig, siginfo_t* info, void* context) {
+    extern(C) private void nativeCrashSignalHandler(int sig, siginfo_t* info, void* context) nothrow @nogc {
         if (nativeCrashHandlerActive) {
             _exit(128 + sig);
         }
         nativeCrashHandlerActive = 1;
 
-        // Keep the crashdump write path nogc before running the best-effort UI notifier.
         writeNativeCrashDumpFromSignal(sig);
         notifyNativeCrashUserAfterSignal();
 
@@ -225,6 +223,9 @@ version(Posix) {
     }
 
     void installNativeCrashDumpHandler() {
+        copyNativeCrashDumpPath(thisExePath());
+        nativeCrashExePath = nativeCrashDumpPath;
+        nativeCrashExePathLen = nativeCrashDumpPathLen;
         mkdirCrashDumpDir();
         copyNativeCrashDumpPath(genCrashDumpPath("nijigenerate-native-crashdump"));
         installNativeCrashDumpThreadHandler();

--- a/source/nijigenerate/utils/crashdump.d
+++ b/source/nijigenerate/utils/crashdump.d
@@ -144,12 +144,7 @@ version(Posix) {
         writeAll(fd, buf[pos .. $]);
     }
 
-    extern(C) private void nativeCrashSignalHandler(int sig, siginfo_t* info, void* context) {
-        if (nativeCrashHandlerActive) {
-            _exit(128 + sig);
-        }
-        nativeCrashHandlerActive = 1;
-
+    private void writeNativeCrashDumpFromSignal(int sig) nothrow @nogc {
         int fd = -1;
         if (nativeCrashDumpPathLen > 0) {
             fd = open(nativeCrashDumpPath.ptr, O_WRONLY | O_CREAT | O_TRUNC, cast(mode_t)384); // 0600
@@ -176,7 +171,9 @@ version(Posix) {
             writeAll(fd, "  atos -o <nijigenerate-binary> -arch arm64 <address>\n");
             close(fd);
         }
+    }
 
+    private void notifyNativeCrashUserAfterSignal() {
         // crashdump() is not reached on SIGSEGV; fork a child to notify the user.
         auto pid = fork();
         if (pid == 0) {
@@ -187,6 +184,17 @@ version(Posix) {
             } catch (Throwable) {}
             _exit(0);
         }
+    }
+
+    extern(C) private void nativeCrashSignalHandler(int sig, siginfo_t* info, void* context) {
+        if (nativeCrashHandlerActive) {
+            _exit(128 + sig);
+        }
+        nativeCrashHandlerActive = 1;
+
+        // Keep the crashdump write path nogc before running the best-effort UI notifier.
+        writeNativeCrashDumpFromSignal(sig);
+        notifyNativeCrashUserAfterSignal();
 
         // SA_RESETHAND has already restored the default handler; re-raise so
         // the process still terminates as a native crash and OS reports remain useful.


### PR DESCRIPTION
Notify users after native SIGSEGV via forked notifyCrashUser, use tinyfd for POSIX crash dialogs, and run crashdump before rethrow in debug builds.

native crash
<img width="868" height="662" alt="image" src="https://github.com/user-attachments/assets/720fc743-c659-4795-8853-425a3499979c" />

dlang throw crash
<img width="882" height="640" alt="image" src="https://github.com/user-attachments/assets/229f482a-9198-4c4f-aa77-7c7a3446523c" />
