### PR TITLE
Fix standard parameter setup and resource parameter creation

### DIFF
--- a/source/nijigenerate/actions/parameter.d
+++ b/source/nijigenerate/actions/parameter.d
@@ -23,16 +23,21 @@ import std.algorithm.mutation : remove;
 class ParameterAddRemoveAction(bool added = true) : Action {
 public:
     Parameter self;
+    Puppet puppet;
     Driver[] drivers;
 //    Parameter[]* parentList;
     ExParameterGroup originalParent;
     long indexInGroup;
 
     this(Parameter self, Parameter[]* parentList) {
-        this(self);
+        this(self, incActivePuppet());
     }
     this(Parameter self) {
+        this(self, incActivePuppet());
+    }
+    this(Parameter self, Puppet puppet) {
         this.self = self;
+        this.puppet = puppet;
 //        this.parentList = parentList;
 
         auto exParam = cast(ExParameter)self;
@@ -40,7 +45,7 @@ public:
         indexInGroup = -1;
 
         // Find drivers
-        foreach(ref driver; incActivePuppet().getDrivers()) {
+        foreach(ref driver; puppet.getDrivers()) {
             if (SimplePhysics sf = cast(SimplePhysics)driver) {
                 if (sf.param !is null && sf.param.uuid == self.uuid) {
                     drivers ~= driver;
@@ -54,7 +59,7 @@ public:
                 sf.param = null;
             }
         }
-        incActivePuppet().root.notifyChange(incActivePuppet().root, NotifyReason.StructureChanged);
+        notifyParameterResourceChanged();
     }
 
     /**
@@ -69,12 +74,12 @@ public:
             indexInGroup = originalParent? originalParent.children.countUntil(exParam): -1;
         }
         if (!added) {
-            incActivePuppet().parameters ~= self;
+            puppet.parameters ~= self;
             if (exParam !is null)
                 exParam.setParent(newParent);
         } else {
 
-            incActivePuppet().removeParameter(self);
+            puppet.removeParameter(self);
         }
             
         // Re-apply drivers
@@ -83,7 +88,7 @@ public:
                 sf.param = self;
             }
         }
-        incActivePuppet().root.notifyChange(incActivePuppet().root, NotifyReason.StructureChanged);
+        notifyParameterResourceChanged();
     }
 
     /**
@@ -98,11 +103,11 @@ public:
             indexInGroup = originalParent? originalParent.children.countUntil(exParam): -1;
         }
         if (added) {
-            incActivePuppet().parameters ~= self;
+            puppet.parameters ~= self;
             if (exParam !is null)
                 exParam.setParent(newParent);
         } else {
-            incActivePuppet().removeParameter(self);
+            puppet.removeParameter(self);
         }
             
         // Empty drivers
@@ -111,7 +116,7 @@ public:
                 sf.param = null;
             }
         }
-        incActivePuppet().root.notifyChange(incActivePuppet().root, NotifyReason.StructureChanged);
+        notifyParameterResourceChanged();
     }
 
     /**
@@ -143,6 +148,12 @@ public:
     
     bool merge(Action other) { return false; }
     bool canMerge(Action other) { return false; }
+
+private:
+    void notifyParameterResourceChanged() {
+        if (puppet !is null && puppet.root !is null)
+            puppet.root.notifyChange(puppet.root, NotifyReason.StructureChanged);
+    }
 }
 
 alias ParameterAddAction = ParameterAddRemoveAction!true;

--- a/source/nijigenerate/commands/depth/bone.d
+++ b/source/nijigenerate/commands/depth/bone.d
@@ -3,7 +3,7 @@ module nijigenerate.commands.depth.bone;
 import nijigenerate.commands.base;
 import nijigenerate.actions;
 import nijigenerate.actions.binding : ngDepthBoneBindingValueChangeHook;
-import nijigenerate.actions.parameter : ParameterChangeBindingsValueAction;
+import nijigenerate.actions.parameter : ParameterChangeBindingsValueAction, ParameterShapeChangeAction;
 import nijigenerate.core.actionstack : incActionPush;
 import nijigenerate.ext : ExParameter;
 import nijigenerate.ext.nodes.exdepthbone;
@@ -1988,11 +1988,11 @@ private StandardDepthBoneBindingSpec[] standardDepthBoneBindingSpecs() {
     ];
 }
 
-private Parameter findDepthParameterByName(string name) {
+private Parameter findDepthParameterByName(string name, bool isVec2) {
     auto puppet = incActivePuppet();
     if (puppet is null) return null;
     foreach (param; puppet.parameters) {
-        if (param.name == name) return param;
+        if (param.name == name && param.isVec2 == isVec2) return param;
     }
     return null;
 }
@@ -2005,20 +2005,79 @@ private float parameterAxisValue(Parameter param, size_t axis, size_t index) {
     return minValue + span * param.axisPoints[axis][index];
 }
 
-private bool axisMatches(const float[] actual, const float[] expected) {
-    if (actual.length != expected.length) return false;
-    foreach (i, value; actual) {
-        if (abs(value - expected[i]) > 0.000001f) return false;
-    }
-    return true;
-}
-
-private bool parameterMatchesSpec(Parameter param, ref StandardDepthParameterSpec spec) {
+private bool parameterStructureMatchesSpec(Parameter param, ref StandardDepthParameterSpec spec) {
     if (param is null) return false;
     if (param.isVec2 != spec.isVec2) return false;
     if (abs(param.min.x - spec.minValue.x) > 0.000001f || abs(param.max.x - spec.maxValue.x) > 0.000001f) return false;
     if (spec.isVec2 && (abs(param.min.y - spec.minValue.y) > 0.000001f || abs(param.max.y - spec.maxValue.y) > 0.000001f)) return false;
-    return axisMatches(param.axisPoints[0], spec.axisX) && axisMatches(param.axisPoints[1], spec.axisY);
+    return true;
+}
+
+private bool parameterHasAxisValue(Parameter param, uint axis, float value) {
+    enum float eps = 0.000001f;
+    if (!param.isVec2 && axis == 1)
+        return abs(value) <= eps;
+    foreach (i; 0 .. param.axisPoints[axis].length) {
+        if (abs(parameterAxisValue(param, axis, i) - value) <= eps)
+            return true;
+    }
+    return false;
+}
+
+private void ensureParameterAxisValue(Parameter param, uint axis, float value) {
+    enum float eps = 0.000001f;
+    if (!param.isVec2 && axis == 1) return;
+    if (parameterHasAxisValue(param, axis, value)) return;
+
+    auto minValue = axis == 0 ? param.min.x : param.min.y;
+    auto maxValue = axis == 0 ? param.max.x : param.max.y;
+    auto span = maxValue - minValue;
+    if (abs(span) <= eps) return;
+    auto offset = (value - minValue) / span;
+    if (offset > eps && offset < 1.0f - eps)
+        param.insertAxisPoint(axis, offset);
+}
+
+private bool standardDepthParameterHasRequiredKeys(Parameter param, StandardDepthBoneBindingSpec[] bindingSpecs) {
+    foreach (bindingSpec; bindingSpecs) {
+        foreach (valueSpec; bindingSpec.values) {
+            if (!parameterHasAxisValue(param, 0, valueSpec.paramValue.x)) return false;
+            if (!parameterHasAxisValue(param, 1, valueSpec.paramValue.y)) return false;
+        }
+    }
+    return true;
+}
+
+private void ensureStandardDepthParameterKeys(Parameter param, StandardDepthBoneBindingSpec[] bindingSpecs) {
+    foreach (bindingSpec; bindingSpecs) {
+        foreach (valueSpec; bindingSpec.values) {
+            ensureParameterAxisValue(param, 0, valueSpec.paramValue.x);
+            ensureParameterAxisValue(param, 1, valueSpec.paramValue.y);
+        }
+    }
+}
+
+private bool conformStandardDepthParameter(Parameter param, ref StandardDepthParameterSpec spec, StandardDepthBoneBindingSpec[] bindingSpecs, GroupAction group, out bool changed, out string message) {
+    changed = false;
+    if (param.isVec2 != spec.isVec2) {
+        message = _("Existing parameter '%s' is %s but the standard depth template requires %s").format(
+            spec.name,
+            param.isVec2 ? "2D" : "1D",
+            spec.isVec2 ? "2D" : "1D"
+        );
+        return false;
+    }
+    if (parameterStructureMatchesSpec(param, spec) && standardDepthParameterHasRequiredKeys(param, bindingSpecs))
+        return true;
+
+    auto action = new ParameterShapeChangeAction("standard depth parameter axes", param);
+    param.min = spec.minValue;
+    param.max = spec.maxValue;
+    ensureStandardDepthParameterKeys(param, bindingSpecs);
+    action.updateNewState();
+    group.addAction(action);
+    changed = true;
+    return true;
 }
 
 private ExDepthBone findStandardDepthBone(ExDepthRigRoot root, string boneId) {
@@ -2050,10 +2109,13 @@ class AddStandardDepthParametersCommand : ExCommand!(
 
         auto group = new GroupAction();
         Parameter[string] paramsByName;
+        StandardDepthBoneBindingSpec[][string] bindingSpecsByParameter;
+        foreach (bindingSpec; bindingSpecs)
+            bindingSpecsByParameter[bindingSpec.parameterName] ~= bindingSpec;
         bool changed = false;
 
         foreach (spec; standardDepthParameterSpecs()) {
-            auto param = findDepthParameterByName(spec.name);
+            auto param = findDepthParameterByName(spec.name, spec.isVec2);
             if (param is null) {
                 auto created = new ExParameter(spec.name, spec.isVec2);
                 created.min = spec.minValue;
@@ -2067,7 +2129,11 @@ class AddStandardDepthParametersCommand : ExCommand!(
                 param = created;
                 changed = true;
             } else {
-                enforce(parameterMatchesSpec(param, spec), _("Existing parameter '%s' has incompatible keypoints").format(spec.name));
+                string message;
+                bool parameterChanged;
+                if (!conformStandardDepthParameter(param, spec, bindingSpecsByParameter.get(spec.name, null), group, parameterChanged, message))
+                    return CommandResult(false, message);
+                changed = changed || parameterChanged;
             }
             paramsByName[spec.name] = param;
         }

--- a/source/nijigenerate/commands/parameter/param.d
+++ b/source/nijigenerate/commands/parameter/param.d
@@ -28,8 +28,10 @@ class Add1DParameterCommand : ExCommand!(TW!(int, "min", "minimum value of the P
         param.max.x = max;
         if (min + max == 0)
         param.insertAxisPoint(0, 0.5);
-        incActivePuppet().parameters ~= param;
-        incActionPush(new ParameterAddAction(param, &incActivePuppet().parameters));
+        ctx.puppet.parameters ~= param;
+        incActionPush(new ParameterAddAction(param, &ctx.puppet.parameters));
+        if (ctx.puppet.root)
+            ctx.puppet.root.notifyChange(ctx.puppet.root, NotifyReason.StructureChanged);
         auto res = new CreateResult!Parameter(true, [param], "Parameter created");
         return res;
     }
@@ -53,8 +55,10 @@ class Add2DParameterCommand : ExCommand!(TW!(int, "min", "minimum value of the P
             param.insertAxisPoint(0, 0.5);
             param.insertAxisPoint(1, 0.5);
         }
-        incActivePuppet().parameters ~= param;
-        incActionPush(new ParameterAddAction(param, &incActivePuppet().parameters));
+        ctx.puppet.parameters ~= param;
+        incActionPush(new ParameterAddAction(param, &ctx.puppet.parameters));
+        if (ctx.puppet.root)
+            ctx.puppet.root.notifyChange(ctx.puppet.root, NotifyReason.StructureChanged);
         auto res = new CreateResult!Parameter(true, [param], "Parameter created");
         return res;
     }
@@ -80,8 +84,10 @@ class AddMouthParameterCommand : ExCommand!() {
         param.insertAxisPoint(1, 0.3);
         param.insertAxisPoint(1, 0.5);
         param.insertAxisPoint(1, 0.6);
-        incActivePuppet().parameters ~= param;
-        incActionPush(new ParameterAddAction(param, &incActivePuppet().parameters));
+        ctx.puppet.parameters ~= param;
+        incActionPush(new ParameterAddAction(param, &ctx.puppet.parameters));
+        if (ctx.puppet.root)
+            ctx.puppet.root.notifyChange(ctx.puppet.root, NotifyReason.StructureChanged);
         auto res = new CreateResult!Parameter(true, [param], "Parameter created");
         return res;
     }
@@ -95,6 +101,8 @@ class RemoveParameterCommand : ExCommand!() {
         if (!ctx.hasParameters) return new DeleteResult!Parameter(false, null, "No parameters");
         foreach (param; ctx.parameters)
             removeParameter(param);
+        if (ctx.hasPuppet && ctx.puppet.root)
+            ctx.puppet.root.notifyChange(ctx.puppet.root, NotifyReason.StructureChanged);
         auto res = new DeleteResult!Parameter(true, ctx.parameters.dup, "Parameters removed");
         return res;
     }

--- a/source/nijigenerate/commands/parameter/param.d
+++ b/source/nijigenerate/commands/parameter/param.d
@@ -29,9 +29,7 @@ class Add1DParameterCommand : ExCommand!(TW!(int, "min", "minimum value of the P
         if (min + max == 0)
         param.insertAxisPoint(0, 0.5);
         ctx.puppet.parameters ~= param;
-        incActionPush(new ParameterAddAction(param, &ctx.puppet.parameters));
-        if (ctx.puppet.root)
-            ctx.puppet.root.notifyChange(ctx.puppet.root, NotifyReason.StructureChanged);
+        incActionPush(new ParameterAddAction(param, ctx.puppet));
         auto res = new CreateResult!Parameter(true, [param], "Parameter created");
         return res;
     }
@@ -56,9 +54,7 @@ class Add2DParameterCommand : ExCommand!(TW!(int, "min", "minimum value of the P
             param.insertAxisPoint(1, 0.5);
         }
         ctx.puppet.parameters ~= param;
-        incActionPush(new ParameterAddAction(param, &ctx.puppet.parameters));
-        if (ctx.puppet.root)
-            ctx.puppet.root.notifyChange(ctx.puppet.root, NotifyReason.StructureChanged);
+        incActionPush(new ParameterAddAction(param, ctx.puppet));
         auto res = new CreateResult!Parameter(true, [param], "Parameter created");
         return res;
     }
@@ -85,9 +81,7 @@ class AddMouthParameterCommand : ExCommand!() {
         param.insertAxisPoint(1, 0.5);
         param.insertAxisPoint(1, 0.6);
         ctx.puppet.parameters ~= param;
-        incActionPush(new ParameterAddAction(param, &ctx.puppet.parameters));
-        if (ctx.puppet.root)
-            ctx.puppet.root.notifyChange(ctx.puppet.root, NotifyReason.StructureChanged);
+        incActionPush(new ParameterAddAction(param, ctx.puppet));
         auto res = new CreateResult!Parameter(true, [param], "Parameter created");
         return res;
     }
@@ -101,8 +95,6 @@ class RemoveParameterCommand : ExCommand!() {
         if (!ctx.hasParameters) return new DeleteResult!Parameter(false, null, "No parameters");
         foreach (param; ctx.parameters)
             removeParameter(param);
-        if (ctx.hasPuppet && ctx.puppet.root)
-            ctx.puppet.root.notifyChange(ctx.puppet.root, NotifyReason.StructureChanged);
         auto res = new DeleteResult!Parameter(true, ctx.parameters.dup, "Parameters removed");
         return res;
     }

--- a/source/nijigenerate/panels/resource.d
+++ b/source/nijigenerate/panels/resource.d
@@ -172,6 +172,8 @@ protected:
 
     override
     void onUpdate() {
+        incRunPendingParameterUiCommand();
+
         if (incActivePuppet() != activePuppet) {
             activePuppet = incActivePuppet();
             if (activePuppet) {
@@ -294,4 +296,3 @@ public:
     Generate logger frame
 */
 //mixin incPanel!ResourcePanel;
-

--- a/source/nijigenerate_tests/regression.d
+++ b/source/nijigenerate_tests/regression.d
@@ -4064,11 +4064,21 @@ private void assertAxisPoints(Parameter param, int axis, scope const(float)[] ex
 private void testParameterCreatePresets() {
     resetCase();
 
+    auto resourcePanelSource = readText(regressionSourceRoot("panels/resource.d"));
+    require(resourcePanelSource.canFind("incRunPendingParameterUiCommand();"),
+        "ResourcePanel should execute queued parameter menu commands from its Add Resource and right-click menus");
+
     auto ctx = new Context();
     ctx.puppet = incActivePuppet();
+    bool resourceStructureNotified;
+    incActivePuppet().root.addNotifyListener((Node target, NotifyReason reason) {
+        if (target is incActivePuppet().root && reason == NotifyReason.StructureChanged)
+            resourceStructureNotified = true;
+    });
 
     auto onePositiveResult = (new Add1DParameterCommand(0, 1)).run(ctx);
     require(onePositiveResult.succeeded, "Add1DParameterCommand 0..1 should succeed");
+    require(resourceStructureNotified, "Add1DParameterCommand should notify resource views after creating a parameter");
     auto onePositive = onePositiveResult.created[0];
     require(!onePositive.isVec2, "0..1 preset should create 1D parameter");
     require(near(onePositive.min.x, 0) && near(onePositive.max.x, 1), "0..1 preset should set range");
@@ -5450,6 +5460,115 @@ private void testDepthBoneStandardParameterTemplate() {
 
     incActionRedo();
     require(findParameter(incActivePuppet(), "Face::Yaw-Pitch") !is null, "redo standard depth parameters should restore created parameters");
+
+    resetCase();
+
+    auto conflictRoot = new ExDepthRigRoot(incActivePuppet().root);
+    conflictRoot.name = "template-depth-param-conflict-root";
+    ngAddStandardDepthSkeleton(conflictRoot, 1000.0f);
+
+    auto existingFaceRoll = new ExParameter("Face::Roll", false);
+    existingFaceRoll.min = vec2(-30.0f, 0.0f);
+    existingFaceRoll.max = vec2(30.0f, 0.0f);
+    existingFaceRoll.insertAxisPoint(0, 0.5f);
+    incActivePuppet().parameters ~= existingFaceRoll;
+    require(existingFaceRoll.axisPoints[0].length == 3, "test fixture Face::Roll should start with a non-template but sufficient 3-key axis");
+
+    auto conflictCommand = new AddStandardDepthParametersCommand();
+    conflictCommand.root = conflictRoot;
+    auto conflictResult = conflictCommand.run(new Context());
+    require(conflictResult.succeeded, "AddStandardDepthParametersCommand should reuse compatible existing standard parameters instead of throwing");
+    require(findParameter(incActivePuppet(), "Face::Roll") is existingFaceRoll, "standard depth parameter setup should reuse the existing Face::Roll");
+    require(existingFaceRoll.axisPoints[0].length == 3 && existingFaceRoll.axisPoints[1].length == 1,
+        "standard depth parameter setup should not force Face::Roll to the template grid when required paramValue keys already exist");
+    require(near(existingFaceRoll.min.x, -1.0f) && near(existingFaceRoll.max.x, 1.0f),
+        "standard depth parameter setup should normalize Face::Roll range");
+
+    auto neck = findDepthBoneById(conflictRoot, "Neck");
+    auto neckRoll = cast(ValueParameterBinding)existingFaceRoll.getBinding(neck, "transform.r.z");
+    require(neckRoll !is null, "standard depth parameter setup should bind existing Face::Roll to Neck transform.r.z");
+
+    incActionUndo();
+    require(findParameter(incActivePuppet(), "Face::Roll") is existingFaceRoll,
+        "undo standard depth parameter setup should keep pre-existing Face::Roll");
+    require(existingFaceRoll.axisPoints[0].length == 3 && near(existingFaceRoll.min.x, -30.0f) && near(existingFaceRoll.max.x, 30.0f),
+        "undo standard depth parameter setup should restore Face::Roll range without requiring template axis count");
+
+    incActionRedo();
+    require(existingFaceRoll.axisPoints[0].length == 3 && near(existingFaceRoll.min.x, -1.0f) && near(existingFaceRoll.max.x, 1.0f),
+        "redo standard depth parameter setup should preserve sufficient Face::Roll keypoints");
+
+    resetCase();
+
+    auto missingKeyRoot = new ExDepthRigRoot(incActivePuppet().root);
+    missingKeyRoot.name = "template-depth-param-missing-key-root";
+    ngAddStandardDepthSkeleton(missingKeyRoot, 1000.0f);
+
+    auto missingKeyFaceRoll = new ExParameter("Face::Roll", false);
+    missingKeyFaceRoll.min = vec2(-1.0f, 0.0f);
+    missingKeyFaceRoll.max = vec2(1.0f, 0.0f);
+    missingKeyFaceRoll.insertAxisPoint(0, 0.25f);
+    incActivePuppet().parameters ~= missingKeyFaceRoll;
+    require(missingKeyFaceRoll.axisPoints[0].length == 3, "test fixture Face::Roll should miss the 0 standard paramValue key");
+
+    auto missingKeyCommand = new AddStandardDepthParametersCommand();
+    missingKeyCommand.root = missingKeyRoot;
+    require(missingKeyCommand.run(new Context()).succeeded,
+        "AddStandardDepthParametersCommand should add only missing paramValue keypoints for existing parameters");
+    require(missingKeyFaceRoll.axisPoints[0].length == 4,
+        "standard depth parameter setup should add only the missing interior paramValue key");
+    auto missingKeyNeck = findDepthBoneById(missingKeyRoot, "Neck");
+    auto missingKeyNeckRoll = cast(ValueParameterBinding)missingKeyFaceRoll.getBinding(missingKeyNeck, "transform.r.z");
+    require(missingKeyNeckRoll !is null && near(missingKeyNeckRoll.getValue(vec2u(3, 0)), 0.41887903f),
+        "standard depth parameter setup should set binding values at required endpoint paramValue keys");
+
+    incActionUndo();
+    require(missingKeyFaceRoll.getBinding(missingKeyNeck, "transform.r.z") is null,
+        "undo missing-key standard depth parameter setup should remove created binding");
+
+    incActionRedo();
+    require(missingKeyFaceRoll.getBinding(missingKeyNeck, "transform.r.z") !is null,
+        "redo missing-key standard depth parameter setup should restore created binding");
+
+    resetCase();
+
+    auto typeConflictRoot = new ExDepthRigRoot(incActivePuppet().root);
+    typeConflictRoot.name = "template-depth-param-type-conflict-root";
+    ngAddStandardDepthSkeleton(typeConflictRoot, 1000.0f);
+
+    auto wrongTypeFaceRoll = new ExParameter("Face::Roll", true);
+    incActivePuppet().parameters ~= wrongTypeFaceRoll;
+    auto typeConflictCommand = new AddStandardDepthParametersCommand();
+    typeConflictCommand.root = typeConflictRoot;
+    require(typeConflictCommand.run(new Context()).succeeded,
+        "AddStandardDepthParametersCommand should create standard parameters even when a same-name incompatible parameter exists");
+    auto standardFaceRollCount = 0;
+    Parameter standardFaceRoll;
+    foreach (param; incActivePuppet().parameters) {
+        if (param.name == "Face::Roll" && !param.isVec2) {
+            standardFaceRollCount++;
+            standardFaceRoll = param;
+        }
+    }
+    require(standardFaceRollCount == 1 && standardFaceRoll !is null,
+        "same-name incompatible Face::Roll should not block creation of a standard 1D Face::Roll");
+    require(wrongTypeFaceRoll.isVec2, "same-name incompatible Face::Roll should not be mutated into a standard parameter");
+
+    incActionUndo();
+    standardFaceRollCount = 0;
+    foreach (param; incActivePuppet().parameters)
+        if (param.name == "Face::Roll" && !param.isVec2)
+            standardFaceRollCount++;
+    require(standardFaceRollCount == 0 && incActivePuppet().parameters.canFind(wrongTypeFaceRoll),
+        "undo type-conflict standard depth setup should remove created standard Face::Roll and keep the pre-existing incompatible one");
+
+    incActionRedo();
+    standardFaceRollCount = 0;
+    foreach (param; incActivePuppet().parameters)
+        if (param.name == "Face::Roll" && !param.isVec2)
+            standardFaceRollCount++;
+    require(standardFaceRollCount == 1,
+        "redo type-conflict standard depth setup should recreate the standard Face::Roll");
 }
 
 private void testDepthBoneInfluenceRuleCommandUndoRedo() {

--- a/source/nijigenerate_tests/regression.d
+++ b/source/nijigenerate_tests/regression.d
@@ -4079,6 +4079,12 @@ private void testParameterCreatePresets() {
     auto onePositiveResult = (new Add1DParameterCommand(0, 1)).run(ctx);
     require(onePositiveResult.succeeded, "Add1DParameterCommand 0..1 should succeed");
     require(resourceStructureNotified, "Add1DParameterCommand should notify resource views after creating a parameter");
+    resourceStructureNotified = false;
+    incActionUndo();
+    require(resourceStructureNotified, "undo Add1DParameterCommand should notify resource views after removing a parameter");
+    resourceStructureNotified = false;
+    incActionRedo();
+    require(resourceStructureNotified, "redo Add1DParameterCommand should notify resource views after restoring a parameter");
     auto onePositive = onePositiveResult.created[0];
     require(!onePositive.isVec2, "0..1 preset should create 1D parameter");
     require(near(onePositive.min.x, 0) && near(onePositive.max.x, 1), "0..1 preset should set range");


### PR DESCRIPTION
## Summary
- Reuse compatible existing standard depth parameters and add only missing paramValue keypoints before creating depth bindings
- Allow same-name incompatible parameters to coexist while creating the required standard depth parameters
- Execute queued parameter creation commands from the Resource panel and notify resource views after parameter add/remove
- Add regression coverage for standard depth setup, undo/redo, and Resource panel parameter creation refresh paths

Fixes #177

## Validation
- dub build -c regression-tests -q
- ./out/nijigenerate-regression-tests --only parameter.template-depth-bone
- ./out/nijigenerate-regression-tests --only parameter.create-presets
- dub build -c osx-full -q
- ./out/nijigenerate-regression-tests
- git diff --check