### PR TITLE
Fix DynamicComposite reparent transform drift

### DIFF
--- a/source/nijigenerate/actions/node.d
+++ b/source/nijigenerate/actions/node.d
@@ -104,7 +104,7 @@ public:
                 }
                 if (!sn.lockToRoot()) {
                     sn.localTransform.translation = Node.getRelativePosition(
-                        new_.transformNoLock.matrix,
+                        new_.transform.matrix,
                         tmpTransform.matrix
                     );
                     sn.localTransform.update();

--- a/source/nijigenerate_tests/regression.d
+++ b/source/nijigenerate_tests/regression.d
@@ -1975,6 +1975,32 @@ private void testNodeCommandMovePreservesWorldTransform() {
     incActionRedo();
     require(child.parent is parentB, "redo MoveNodeCommand should reparent transformed child again");
     require(nearVec3(nodeWorldTranslation(child), before), "redo MoveNodeCommand should preserve child world translation again");
+
+    auto dynamicParent = new DynamicComposite(incActivePuppet().root);
+    dynamicParent.name = "transform-dynamic-parent";
+    dynamicParent.localTransform = Transform(
+        vec3(30, -12, 0),
+        vec3(0, 0, 0.45f),
+        vec2(2.0f, 0.5f)
+    );
+    dynamicParent.transformChanged();
+
+    auto dynamicBefore = nodeWorldTranslation(child);
+    foreach (i; 0 .. 5) {
+        ctx.nodes = [child];
+        require((new MoveNodeCommand(dynamicParent, 0)).run(ctx).succeeded,
+            "MoveNodeCommand should move child into DynamicComposite on iteration " ~ i.to!string);
+        require(child.parent is dynamicParent, "MoveNodeCommand should parent child under DynamicComposite");
+        require(nearVec3(nodeWorldTranslation(child), dynamicBefore),
+            "MoveNodeCommand should preserve world translation inside DynamicComposite on iteration " ~ i.to!string);
+
+        ctx.nodes = [child];
+        require((new MoveNodeCommand(parentA, 0)).run(ctx).succeeded,
+            "MoveNodeCommand should move child out of DynamicComposite on iteration " ~ i.to!string);
+        require(child.parent is parentA, "MoveNodeCommand should restore child under normal parent");
+        require(nearVec3(nodeWorldTranslation(child), dynamicBefore),
+            "MoveNodeCommand should not accumulate DynamicComposite drift on iteration " ~ i.to!string);
+    }
 }
 
 private void testNodeCentralizeCommandUndoRedo() {


### PR DESCRIPTION
## Summary
- Fix node reparenting so DynamicComposite-style parents use the resolved transform matrix
- Add a regression test for repeated reparenting into and out of a transformed parent
- Cover the nijilive issue [#43](https://github.com/nijigenerate/nijilive/pull/43) coordinate drift scenario from the nijigenerate side

## Verification
- dub build -q -c regression-tests
- out/nijigenerate-regression-tests --only node.reparent-order