### PR TITLE
Fix transform preservation for DynamicComposite conversion

### DIFF
--- a/source/nijigenerate/actions/node.d
+++ b/source/nijigenerate/actions/node.d
@@ -29,6 +29,7 @@ import std.algorithm.searching;
 import std.algorithm;
 import std.range:zip;
 import std.array;
+import std.math : abs;
 /**
     An action that happens when a node is changed
 */
@@ -379,6 +380,23 @@ public:
     bool deepCopy;
     ParameterChangeBindingsValueAction[] bindingReorderActions;
 
+    private static float nonZeroScale(float value) {
+        return abs(value) < 0.0001f ? 1.0f : value;
+    }
+
+    private static void restoreWorldTransformUnder(Node child, Node parent, Transform worldTransform) {
+        Transform parentTransform = parent is null ? Transform(vec3(0, 0, 0)) : parent.transform();
+
+        child.localTransform.translation = Node.getRelativePosition(parentTransform.matrix, worldTransform.matrix);
+        child.localTransform.rotation = worldTransform.rotation - parentTransform.rotation;
+        child.localTransform.scale = vec2(
+            worldTransform.scale.x / nonZeroScale(parentTransform.scale.x),
+            worldTransform.scale.y / nonZeroScale(parentTransform.scale.y)
+        );
+        child.localTransform.update();
+        child.transformChanged();
+    }
+
     private void applyReorderOps(bool forward) {
         foreach (action; bindingReorderActions) {
             if (forward)
@@ -401,10 +419,8 @@ public:
             deepCopy = false;
         }
         this.deepCopy = deepCopy;
-        if (deepCopy) {
-            if (srcNode.children.length > 0)
-                children = srcNode.children.dup;
-        }
+        if (srcNode.children.length > 0)
+            children = srcNode.children.dup;
 
         // Set visual name
         descrName = src.name;
@@ -423,7 +439,7 @@ public:
         assert(parent !is null);
         ulong pOffset = parent.children.countUntil(toNode);
         Transform tmpTransform = toNode.localTransform;
-        auto childTransforms   = children? children.map!((c)=>c.localTransform).array: null;
+        auto childWorldTransforms = children? children.map!((c)=>c.transform()).array: null;
         toNode.reparent(null, 0);
         srcNode.reparent(parent, pOffset, true);
         srcNode.localTransform = tmpTransform;
@@ -433,10 +449,15 @@ public:
         if (deepCopy && children) {
             foreach (i, child; children) {
                 child.reparent(srcNode, i, true);
-                child.localTransform = childTransforms[i];
-                child.transformChanged();
+                restoreWorldTransformUnder(child, srcNode, childWorldTransforms[i]);
                 child.notifyChange(child, NotifyReason.StructureChanged);
             }
+        } else if (children) {
+            foreach (i, child; children) {
+                restoreWorldTransformUnder(child, child.parent, childWorldTransforms[i]);
+                child.notifyChange(child, NotifyReason.StructureChanged);
+            }
+            srcNode.notifyChange(srcNode, NotifyReason.StructureChanged);
         } else
             srcNode.notifyChange(srcNode, NotifyReason.StructureChanged);
     
@@ -454,7 +475,7 @@ public:
         assert(parent !is null);
         ulong pOffset = parent.children.countUntil(srcNode);
         Transform tmpTransform = srcNode.localTransform;
-        auto childTransforms   = children? children.map!((c)=>c.localTransform).array: null;
+        auto childWorldTransforms = children? children.map!((c)=>c.transform()).array: null;
         srcNode.reparent(null, 0);
         toNode.reparent(parent, pOffset, true);
         toNode.localTransform = tmpTransform;
@@ -464,10 +485,15 @@ public:
         if (deepCopy && children) {
             foreach (i, child; children) {
                 child.reparent(toNode, i, true);
-                child.localTransform = childTransforms[i];
-                child.transformChanged();
+                restoreWorldTransformUnder(child, toNode, childWorldTransforms[i]);
                 child.notifyChange(child, NotifyReason.StructureChanged);
             }
+        } else if (children) {
+            foreach (i, child; children) {
+                restoreWorldTransformUnder(child, child.parent, childWorldTransforms[i]);
+                child.notifyChange(child, NotifyReason.StructureChanged);
+            }
+            toNode.notifyChange(toNode, NotifyReason.StructureChanged);
         } else
             toNode.notifyChange(toNode, NotifyReason.StructureChanged);
 

--- a/source/nijigenerate/actions/node.d
+++ b/source/nijigenerate/actions/node.d
@@ -384,14 +384,38 @@ public:
         return abs(value) < 0.0001f ? 1.0f : value;
     }
 
-    private static void restoreWorldTransformUnder(Node child, Node parent, Transform worldTransform) {
-        Transform parentTransform = parent is null ? Transform(vec3(0, 0, 0)) : parent.transform();
+    private static Transform rootTransformFor() {
+        auto puppet = incActivePuppet();
+        if (puppet !is null && puppet.root !is null)
+            return puppet.root.localTransform;
+        return Transform(vec3(0, 0, 0));
+    }
 
-        child.localTransform.translation = Node.getRelativePosition(parentTransform.matrix, worldTransform.matrix);
-        child.localTransform.rotation = worldTransform.rotation - parentTransform.rotation;
-        child.localTransform.scale = vec2(
+    private static void restoreWorldTransformUnder(Node child, Node parent, Transform worldTransform) {
+        Transform parentTransform = child.lockToRoot()
+            ? rootTransformFor()
+            : (parent is null ? Transform(vec3(0, 0, 0)) : parent.transform());
+
+        auto localWithOffsetTranslation = Node.getRelativePosition(parentTransform.matrix, worldTransform.matrix);
+        auto localWithOffsetRotation = worldTransform.rotation - parentTransform.rotation;
+        auto localWithOffsetScale = vec2(
             worldTransform.scale.x / nonZeroScale(parentTransform.scale.x),
             worldTransform.scale.y / nonZeroScale(parentTransform.scale.y)
+        );
+
+        child.localTransform.translation = localWithOffsetTranslation - vec3(
+            child.getValue("transform.t.x"),
+            child.getValue("transform.t.y"),
+            child.getValue("transform.t.z")
+        );
+        child.localTransform.rotation = localWithOffsetRotation - vec3(
+            child.getValue("transform.r.x"),
+            child.getValue("transform.r.y"),
+            child.getValue("transform.r.z")
+        );
+        child.localTransform.scale = vec2(
+            localWithOffsetScale.x / nonZeroScale(child.getValue("transform.s.x")),
+            localWithOffsetScale.y / nonZeroScale(child.getValue("transform.s.y"))
         );
         child.localTransform.update();
         child.transformChanged();

--- a/source/nijigenerate_tests/regression.d
+++ b/source/nijigenerate_tests/regression.d
@@ -1930,6 +1930,11 @@ private vec3 nodeWorldTranslation(Node node) {
     return vec3(mat.matrix[0][3], mat.matrix[1][3], mat.matrix[2][3]);
 }
 
+private vec3 nodeRenderedWorldTranslation(Node node) {
+    auto mat = node.transform().matrix;
+    return vec3(mat.matrix[0][3], mat.matrix[1][3], mat.matrix[2][3]);
+}
+
 private void testNodeCommandMovePreservesWorldTransform() {
     resetCase();
 
@@ -2650,6 +2655,128 @@ private void testNodeTypeConversionPreservesChildWorldTransform() {
                 "redo conversion should preserve child world rotation for %s -> %s".format(fromType, toType));
             require(nearVec2(child.transform().scale, before.scale),
                 "redo conversion should preserve child world scale for %s -> %s".format(fromType, toType));
+        }
+    }
+}
+
+private void testNodeTypeConversionPreservesLockedAndOffsetChildBaseTransform() {
+    foreach (fromType, toTypes; conversionMap()) {
+        foreach (toType; toTypes) {
+            if (fromType == "DynamicComposite" && (toType == "MeshGroup" || toType == "Part"))
+                continue;
+
+            resetCase();
+            auto node = inInstantiateNode(fromType, incActivePuppet().root);
+            require(node !is null, "conversion source type should instantiate for lockToRoot fixture: " ~ fromType);
+            node.name = fromType ~ "-to-" ~ toType ~ "-locked-source";
+            node.localTransform = Transform(
+                vec3(30, -12, 0),
+                vec3(0, 0, 0.45f),
+                vec2(2.0f, 0.5f)
+            );
+            node.transformChanged();
+
+            auto lockedChild = new Node(node);
+            lockedChild.name = fromType ~ "-to-" ~ toType ~ "-locked-child";
+            lockedChild.localTransform = Transform(
+                vec3(40, -15, 1),
+                vec3(0, 0, 0.2f),
+                vec2(1.2f, 0.9f)
+            );
+            lockedChild.transformChanged();
+            lockedChild.lockToRoot = true;
+            lockedChild.transformChanged();
+
+            auto lockedLocalBefore = lockedChild.localTransform;
+            auto lockedWorldBefore = lockedChild.transform();
+            auto lockedWorldTranslationBefore = nodeRenderedWorldTranslation(lockedChild);
+
+            auto lockedCtx = new Context();
+            lockedCtx.nodes = [node];
+            auto lockedCommand = new ConvertToCommand(toType);
+            require(lockedCommand.run(lockedCtx).succeeded,
+                "ConvertToCommand should convert %s to %s with a lockToRoot child".format(fromType, toType));
+            require(nearVec3(lockedChild.localTransform.translation, lockedLocalBefore.translation),
+                "conversion should not rewrite lockToRoot child local translation for %s -> %s".format(fromType, toType));
+            require(nearVec3(nodeRenderedWorldTranslation(lockedChild), lockedWorldTranslationBefore),
+                "conversion should preserve lockToRoot child world translation for %s -> %s".format(fromType, toType));
+            require(nearVec3(lockedChild.transform().rotation, lockedWorldBefore.rotation),
+                "conversion should preserve lockToRoot child world rotation for %s -> %s".format(fromType, toType));
+            require(nearVec2(lockedChild.transform().scale, lockedWorldBefore.scale),
+                "conversion should preserve lockToRoot child world scale for %s -> %s".format(fromType, toType));
+
+            incActionUndo();
+            require(nearVec3(lockedChild.localTransform.translation, lockedLocalBefore.translation),
+                "undo conversion should not rewrite lockToRoot child local translation for %s -> %s".format(fromType, toType));
+            require(nearVec3(nodeRenderedWorldTranslation(lockedChild), lockedWorldTranslationBefore),
+                "undo conversion should preserve lockToRoot child world translation for %s -> %s".format(fromType, toType));
+
+            incActionRedo();
+            require(nearVec3(lockedChild.localTransform.translation, lockedLocalBefore.translation),
+                "redo conversion should not rewrite lockToRoot child local translation for %s -> %s".format(fromType, toType));
+            require(nearVec3(nodeRenderedWorldTranslation(lockedChild), lockedWorldTranslationBefore),
+                "redo conversion should preserve lockToRoot child world translation for %s -> %s".format(fromType, toType));
+
+            resetCase();
+            node = inInstantiateNode(fromType, incActivePuppet().root);
+            require(node !is null, "conversion source type should instantiate for offset fixture: " ~ fromType);
+            node.name = fromType ~ "-to-" ~ toType ~ "-offset-source";
+            node.localTransform = Transform(
+                vec3(30, -12, 0),
+                vec3(0, 0, 0.45f),
+                vec2(2.0f, 0.5f)
+            );
+            node.transformChanged();
+
+            auto offsetChild = new Node(node);
+            offsetChild.name = fromType ~ "-to-" ~ toType ~ "-offset-child";
+            offsetChild.localTransform = Transform(
+                vec3(40, -15, 1),
+                vec3(0, 0, 0.2f),
+                vec2(1.2f, 0.9f)
+            );
+            require(offsetChild.setValue("transform.t.x", 6.0f), "offset child should accept active X translation offset");
+            require(offsetChild.setValue("transform.t.y", -4.0f), "offset child should accept active Y translation offset");
+            require(offsetChild.setValue("transform.r.z", 0.15f), "offset child should accept active Z rotation offset");
+            require(offsetChild.setValue("transform.s.x", 1.1f), "offset child should accept active X scale offset");
+            require(offsetChild.setValue("transform.s.y", 0.8f), "offset child should accept active Y scale offset");
+
+            auto offsetAppliedBefore = offsetChild.transform();
+            auto offsetAppliedTranslationBefore = nodeRenderedWorldTranslation(offsetChild);
+
+            auto offsetCtx = new Context();
+            offsetCtx.nodes = [node];
+            auto offsetCommand = new ConvertToCommand(toType);
+            require(offsetCommand.run(offsetCtx).succeeded,
+                "ConvertToCommand should convert %s to %s with an offset child".format(fromType, toType));
+            require(nearVec3(nodeRenderedWorldTranslation(offsetChild), offsetAppliedTranslationBefore),
+                "conversion should preserve offset-applied child world translation for %s -> %s".format(fromType, toType));
+            require(nearVec3(offsetChild.transform().rotation, offsetAppliedBefore.rotation),
+                "conversion should preserve offset-applied child world rotation for %s -> %s".format(fromType, toType));
+            require(nearVec2(offsetChild.transform().scale, offsetAppliedBefore.scale),
+                "conversion should preserve offset-applied child world scale for %s -> %s".format(fromType, toType));
+            require(near(offsetChild.getValue("transform.t.x"), 6.0f) &&
+                    near(offsetChild.getValue("transform.t.y"), -4.0f) &&
+                    near(offsetChild.getValue("transform.r.z"), 0.15f) &&
+                    near(offsetChild.getValue("transform.s.x"), 1.1f) &&
+                    near(offsetChild.getValue("transform.s.y"), 0.8f),
+                "conversion should preserve active child transform offset values for %s -> %s".format(fromType, toType));
+
+            incActionUndo();
+            require(nearVec3(nodeRenderedWorldTranslation(offsetChild), offsetAppliedTranslationBefore),
+                "undo conversion should preserve offset-applied child world translation for %s -> %s".format(fromType, toType));
+            require(nearVec3(offsetChild.transform().rotation, offsetAppliedBefore.rotation),
+                "undo conversion should preserve offset-applied child world rotation for %s -> %s".format(fromType, toType));
+            require(nearVec2(offsetChild.transform().scale, offsetAppliedBefore.scale),
+                "undo conversion should preserve offset-applied child world scale for %s -> %s".format(fromType, toType));
+
+            incActionRedo();
+            require(nearVec3(nodeRenderedWorldTranslation(offsetChild), offsetAppliedTranslationBefore),
+                "redo conversion should preserve offset-applied child world translation for %s -> %s".format(fromType, toType));
+            require(nearVec3(offsetChild.transform().rotation, offsetAppliedBefore.rotation),
+                "redo conversion should preserve offset-applied child world rotation for %s -> %s".format(fromType, toType));
+            require(nearVec2(offsetChild.transform().scale, offsetAppliedBefore.scale),
+                "redo conversion should preserve offset-applied child world scale for %s -> %s".format(fromType, toType));
         }
     }
 }
@@ -9480,6 +9607,7 @@ private bool runAutomatedScenario(string id) {
         case "node.type-conversion":
             runCase("node-type-conversion-map-undo-redo", &testNodeTypeConversionMapUndoRedo);
             runCase("node-type-conversion-preserves-child-world-transform", &testNodeTypeConversionPreservesChildWorldTransform);
+            runCase("node-type-conversion-preserves-locked-offset-child-base-transform", &testNodeTypeConversionPreservesLockedAndOffsetChildBaseTransform);
             return true;
         case "node.composite-hierarchy-binding-roundtrip":
             runCase("node-composite-hierarchy-binding-roundtrip", &testNodeCompositeHierarchyBindingRoundTrip);

--- a/source/nijigenerate_tests/regression.d
+++ b/source/nijigenerate_tests/regression.d
@@ -2504,6 +2504,68 @@ private void testNodeConvertCommandUndoRedo() {
     incActionRedo();
     require(isChildOf(incActivePuppet().root, converted), "redo ConvertToCommand should restore converted node");
     require(!isChildOf(incActivePuppet().root, node), "redo ConvertToCommand should remove source node again");
+
+    resetCase();
+
+    MeshData quad;
+    quad.vertices = Vec2Array([
+        vec2(-5, -5),
+        vec2(-5,  5),
+        vec2( 5, -5),
+        vec2( 5,  5),
+    ]);
+    quad.uvs = Vec2Array([
+        vec2(0, 0),
+        vec2(0, 1),
+        vec2(1, 0),
+        vec2(1, 1),
+    ]);
+    quad.indices = [cast(ushort)0, 1, 2, 2, 1, 3];
+    quad.origin = vec2(0, 0);
+
+    auto sourceNode = new Node(incActivePuppet().root);
+    sourceNode.name = "node-to-dynamic-source";
+    sourceNode.localTransform = Transform(
+        vec3(30, -12, 0),
+        vec3(0, 0, 0.45f),
+        vec2(2.0f, 0.5f)
+    );
+    sourceNode.transformChanged();
+
+    auto child = new Part(quad, Texture[].init, inCreateUUID(), sourceNode);
+    child.name = "node-to-dynamic-child";
+    child.localTransform = Transform(
+        vec3(40, -15, 1),
+        vec3(0, 0, 0.2f),
+        vec2(1.2f, 0.9f)
+    );
+    child.transformChanged();
+
+    auto before = child.transform();
+    auto beforeTranslation = nodeWorldTranslation(child);
+    auto convertCtx = new Context();
+    convertCtx.nodes = [sourceNode];
+    auto dynamicResult = (new ConvertToCommand("DynamicComposite")).run(convertCtx);
+    require(dynamicResult.succeeded, "ConvertToCommand should convert Node to DynamicComposite");
+    require(dynamicResult.created.length == 1, "Node to DynamicComposite conversion should return one node");
+    auto dynamic = cast(DynamicComposite)dynamicResult.created[0];
+    require(dynamic !is null, "converted node should be DynamicComposite");
+    require(child.parent is dynamic, "conversion should move the child under DynamicComposite");
+    require(nearVec3(nodeWorldTranslation(child), beforeTranslation), "Node to DynamicComposite conversion should preserve child world translation");
+    require(nearVec3(child.transform().rotation, before.rotation), "Node to DynamicComposite conversion should preserve child world rotation");
+    require(nearVec2(child.transform().scale, before.scale), "Node to DynamicComposite conversion should preserve child world scale");
+
+    incActionUndo();
+    require(child.parent is sourceNode, "undo Node to DynamicComposite conversion should restore the child under the source node");
+    require(nearVec3(nodeWorldTranslation(child), beforeTranslation), "undo Node to DynamicComposite conversion should preserve child world translation");
+    require(nearVec3(child.transform().rotation, before.rotation), "undo Node to DynamicComposite conversion should preserve child world rotation");
+    require(nearVec2(child.transform().scale, before.scale), "undo Node to DynamicComposite conversion should preserve child world scale");
+
+    incActionRedo();
+    require(child.parent is dynamic, "redo Node to DynamicComposite conversion should restore the child under DynamicComposite");
+    require(nearVec3(nodeWorldTranslation(child), beforeTranslation), "redo Node to DynamicComposite conversion should preserve child world translation");
+    require(nearVec3(child.transform().rotation, before.rotation), "redo Node to DynamicComposite conversion should preserve child world rotation");
+    require(nearVec2(child.transform().scale, before.scale), "redo Node to DynamicComposite conversion should preserve child world scale");
 }
 
 private void testNodeTypeConversionMapUndoRedo() {
@@ -2531,6 +2593,63 @@ private void testNodeTypeConversionMapUndoRedo() {
             incActionRedo();
             require(isChildOf(incActivePuppet().root, converted), "redo should restore converted node for %s -> %s".format(fromType, toType));
             require(!isChildOf(incActivePuppet().root, node), "redo should detach source again for %s -> %s".format(fromType, toType));
+        }
+    }
+}
+
+private void testNodeTypeConversionPreservesChildWorldTransform() {
+    foreach (fromType, toTypes; conversionMap()) {
+        foreach (toType; toTypes) {
+            resetCase();
+            auto node = inInstantiateNode(fromType, incActivePuppet().root);
+            require(node !is null, "conversion source type should instantiate for child transform fixture: " ~ fromType);
+            node.name = fromType ~ "-to-" ~ toType ~ "-world-source";
+            node.localTransform = Transform(
+                vec3(30, -12, 0),
+                vec3(0, 0, 0.45f),
+                vec2(2.0f, 0.5f)
+            );
+            node.transformChanged();
+
+            auto child = new Node(node);
+            child.name = fromType ~ "-to-" ~ toType ~ "-world-child";
+            child.localTransform = Transform(
+                vec3(40, -15, 1),
+                vec3(0, 0, 0.2f),
+                vec2(1.2f, 0.9f)
+            );
+            child.transformChanged();
+
+            auto before = child.transform();
+            auto beforeTranslation = nodeWorldTranslation(child);
+            auto ctx = new Context();
+            ctx.nodes = [node];
+            auto command = new ConvertToCommand(toType);
+            require(command.run(ctx).succeeded, "ConvertToCommand should convert %s to %s with a transformed child".format(fromType, toType));
+            auto converted = incActivePuppet().root.children[$ - 1];
+            require(converted.typeId() == toType, "converted node should have destination type in child transform fixture %s -> %s".format(fromType, toType));
+            require(nearVec3(nodeWorldTranslation(child), beforeTranslation),
+                "conversion should preserve child world translation for %s -> %s".format(fromType, toType));
+            require(nearVec3(child.transform().rotation, before.rotation),
+                "conversion should preserve child world rotation for %s -> %s".format(fromType, toType));
+            require(nearVec2(child.transform().scale, before.scale),
+                "conversion should preserve child world scale for %s -> %s".format(fromType, toType));
+
+            incActionUndo();
+            require(nearVec3(nodeWorldTranslation(child), beforeTranslation),
+                "undo conversion should preserve child world translation for %s -> %s".format(fromType, toType));
+            require(nearVec3(child.transform().rotation, before.rotation),
+                "undo conversion should preserve child world rotation for %s -> %s".format(fromType, toType));
+            require(nearVec2(child.transform().scale, before.scale),
+                "undo conversion should preserve child world scale for %s -> %s".format(fromType, toType));
+
+            incActionRedo();
+            require(nearVec3(nodeWorldTranslation(child), beforeTranslation),
+                "redo conversion should preserve child world translation for %s -> %s".format(fromType, toType));
+            require(nearVec3(child.transform().rotation, before.rotation),
+                "redo conversion should preserve child world rotation for %s -> %s".format(fromType, toType));
+            require(nearVec2(child.transform().scale, before.scale),
+                "redo conversion should preserve child world scale for %s -> %s".format(fromType, toType));
         }
     }
 }
@@ -9360,6 +9479,7 @@ private bool runAutomatedScenario(string id) {
             return true;
         case "node.type-conversion":
             runCase("node-type-conversion-map-undo-redo", &testNodeTypeConversionMapUndoRedo);
+            runCase("node-type-conversion-preserves-child-world-transform", &testNodeTypeConversionPreservesChildWorldTransform);
             return true;
         case "node.composite-hierarchy-binding-roundtrip":
             runCase("node-composite-hierarchy-binding-roundtrip", &testNodeCompositeHierarchyBindingRoundTrip);


### PR DESCRIPTION
Preserve child world transforms when converting nodes to/from DynamicComposite
and when reparenting through DynamicComposite-like auto-resized containers.

The previous conversion path could recompute relative transforms from the
wrong effective parent matrix, causing children to drift slightly each time a
node was moved into or out of a DynamicComposite. This change keeps the visible
position stable by preserving child transforms across conversion/reparent
operations.

Regression coverage was added for repeated conversion/reparent scenarios so
the same drift does not reappear.