### PR TITLE
Fix/zh tw translations

### DIFF
--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -30,6 +30,20 @@ Check if the merges make sense, if so replace `<langcode>.po` with `<langcode>_m
 &nbsp;
 &nbsp;
 
+## Validate Your Translation
+Our project uses material icons and includes fmtstr to avoid crashes when loading po or missing icon symbols. Please use the following tools to check
+```sh
+# install dependencies
+pip install babel
+# validate
+python translation-validator.py -f tl/<langcode>.po
+# or validate all
+python translation-validator.py -a
+```
+
+&nbsp;
+&nbsp;
+
 ## I need to reorder format parameters
 To specify which format parameter you're indexing, use the `<index>$` operator.  
 Eg. `%2$s` will index the second entry of the format string.

--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -44,6 +44,28 @@ python translation-validator.py -a
 &nbsp;
 &nbsp;
 
+## Importing Translations from Another .po File
+`po_import.py` merges translations from a source `.po` into a target `.po` **without touching the target's formatting, comments, or whitespace**.
+
+```sh
+# Fill in only empty msgstr entries (safe, non-destructive)
+python3 po_import.py SOURCE.po tl/<langcode>.po
+
+# Write result to a new file instead of modifying the target in-place
+python3 po_import.py SOURCE.po tl/<langcode>.po --out output.po
+
+# Also overwrite non-empty msgstr entries that differ from the source
+python3 po_import.py SOURCE.po tl/<langcode>.po --overwrite
+
+# Include fuzzy entries from the source
+python3 po_import.py SOURCE.po tl/<langcode>.po --use-fuzzy
+```
+
+> **Note:** Fuzzy source entries are skipped by default. The script never modifies comments, `#:` references, flags, or blank lines in the target file.
+
+&nbsp;
+&nbsp;
+
 ## I need to reorder format parameters
 To specify which format parameter you're indexing, use the `<index>$` operator.  
 Eg. `%2$s` will index the second entry of the format string.

--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -41,6 +41,18 @@ python translation-validator.py -f tl/<langcode>.po
 python translation-validator.py -a
 ```
 
+### Check zh-TW locale consistency (zh-TW only)
+Uses OpenCC to flag entries that may not follow zh-TW conventions.
+```sh
+# additional dependency for this check only
+pip install opencc-python-reimplemented
+
+python translation-validator.py -t -f tl/zh-TW.po
+
+# Stricter threshold (only show near-zero change entries)
+python translation-validator.py -t -f tl/zh-TW.po --trad-threshold 0.05
+```
+
 &nbsp;
 &nbsp;
 

--- a/po_import.py
+++ b/po_import.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""
+po_import.py — Import translations from a source .po into a target .po
+without touching the target's formatting, comments, or untranslated entries.
+
+Usage:
+    python3 po_import.py SOURCE.po TARGET.po [--out OUTPUT.po] [--overwrite]
+
+By default:
+  - Only fills in entries where the target msgstr is empty ("").
+  - With --overwrite: also replaces non-empty msgstr in target with source value.
+  - Output is written to TARGET.po in-place unless --out is given.
+  - Fuzzy entries in the source are skipped unless --use-fuzzy is given.
+"""
+
+import argparse
+import re
+import sys
+from copy import deepcopy
+
+
+def parse_po(path: str) -> dict[str, list[str]]:
+    """
+    Parse a .po file and return a dict mapping each msgid (decoded string)
+    to its msgstr lines (list of raw quoted strings as they appear in the file,
+    e.g. ['"hello"', '"world"']).
+
+    Also returns fuzzy flag per msgid.
+    """
+    entries: dict[str, dict] = {}
+
+    with open(path, encoding="utf-8") as f:
+        lines = f.readlines()
+
+    i = 0
+    n = len(lines)
+
+    while i < n:
+        # collect flags for the upcoming entry
+        flags: list[str] = []
+        while i < n and lines[i].startswith("#"):
+            if lines[i].startswith("#,"):
+                flags.extend(p.strip() for p in lines[i][2:].split(","))
+            i += 1
+
+        # skip blank lines between entries
+        while i < n and lines[i].strip() == "":
+            i += 1
+
+        if i >= n:
+            break
+
+        # expect msgid (possibly multi-line)
+        if not lines[i].startswith("msgid "):
+            i += 1
+            continue
+
+        msgid_lines, i = collect_value(lines, i, "msgid")
+        msgstr_lines, i = collect_value(lines, i, "msgstr")
+
+        msgid = decode_po_string(msgid_lines)
+        entries[msgid] = {
+            "msgstr_lines": msgstr_lines,
+            "fuzzy": "fuzzy" in flags,
+        }
+
+    return entries
+
+
+def collect_value(lines: list[str], i: int, keyword: str) -> tuple[list[str], int]:
+    """
+    Collect the quoted string(s) for a keyword like msgid or msgstr.
+    Returns (list_of_raw_quoted_strings, next_index).
+    """
+    n = len(lines)
+    raw: list[str] = []
+
+    if i >= n or not lines[i].startswith(keyword + " "):
+        return raw, i
+
+    first = lines[i][len(keyword) + 1:].strip()
+    raw.append(first)
+    i += 1
+
+    # continuation lines start with '"'
+    while i < n and lines[i].startswith('"'):
+        raw.append(lines[i].strip())
+        i += 1
+
+    return raw, i
+
+
+def decode_po_string(raw_lines: list[str]) -> str:
+    """Decode a list of raw quoted PO strings into a Python string."""
+    result = ""
+    for part in raw_lines:
+        if part.startswith('"') and part.endswith('"'):
+            inner = part[1:-1]
+            # basic unescape
+            inner = inner.replace("\\n", "\n").replace("\\t", "\t").replace('\\"', '"').replace("\\\\", "\\")
+            result += inner
+    return result
+
+
+def rewrite_target(target_path: str, out_path: str, source_entries: dict,
+                   overwrite: bool, use_fuzzy: bool) -> tuple[int, int]:
+    """
+    Read target .po line-by-line and replace msgstr blocks where appropriate.
+    Returns (filled_count, skipped_count).
+    """
+    with open(target_path, encoding="utf-8") as f:
+        lines = f.readlines()
+
+    result: list[str] = []
+    i = 0
+    n = len(lines)
+    filled = 0
+    skipped = 0
+
+    while i < n:
+        line = lines[i]
+
+        # pass-through comment / blank lines until we hit a msgid
+        if not line.startswith("msgid "):
+            result.append(line)
+            i += 1
+            continue
+
+        # --- found a msgid block ---
+        # collect the raw msgid lines (including continuations)
+        msgid_raw_lines: list[str] = []
+        msgid_start = i
+        first = line[len("msgid "):].strip()
+        msgid_raw_lines.append(first)
+        i += 1
+        while i < n and lines[i].startswith('"'):
+            msgid_raw_lines.append(lines[i].strip())
+            i += 1
+
+        msgid = decode_po_string(msgid_raw_lines)
+
+        # emit the msgid lines unchanged
+        for raw in [lines[msgid_start]] + lines[msgid_start + 1:i]:
+            result.append(raw)
+
+        # now expect msgstr (skip intermediate blank / comment lines — unusual but safe)
+        while i < n and lines[i].strip() == "":
+            result.append(lines[i])
+            i += 1
+
+        if i >= n or not lines[i].startswith("msgstr "):
+            # no msgstr found — emit whatever is there and continue
+            continue
+
+        # collect original msgstr lines
+        msgstr_start = i
+        msgstr_lines_orig: list[str] = [lines[i]]
+        i += 1
+        while i < n and lines[i].startswith('"'):
+            msgstr_lines_orig.append(lines[i])
+            i += 1
+
+        current_str = decode_po_string([l.strip() for l in msgstr_lines_orig[0:1]] +
+                                       [l.strip() for l in msgstr_lines_orig[1:]])
+        # re-decode properly
+        raw_collected = []
+        raw_collected.append(msgstr_lines_orig[0][len("msgstr "):].strip())
+        for l in msgstr_lines_orig[1:]:
+            raw_collected.append(l.strip())
+        current_str = decode_po_string(raw_collected)
+
+        src = source_entries.get(msgid)
+        should_replace = False
+
+        if src is not None:
+            if src["fuzzy"] and not use_fuzzy:
+                pass  # skip fuzzy source
+            else:
+                src_str = decode_po_string(src["msgstr_lines"])
+                if src_str == "":
+                    pass  # source is empty — nothing to import
+                elif current_str == "":
+                    should_replace = True
+                elif overwrite and current_str != src_str:
+                    should_replace = True
+
+        if should_replace:
+            # Build replacement msgstr lines from source, preserving target indentation style
+            indent = ""
+            new_lines = build_msgstr_lines(src["msgstr_lines"], indent)
+            result.extend(new_lines)
+            filled += 1
+        else:
+            # keep original msgstr block unchanged
+            result.extend(msgstr_lines_orig)
+            if src is not None and current_str == "" and (src is None or decode_po_string(src["msgstr_lines"]) == ""):
+                pass
+            elif src is not None and should_replace is False and decode_po_string(src["msgstr_lines"]) != "":
+                skipped += 1
+
+    # detect line endings from original
+    with open(target_path, "rb") as f:
+        raw_bytes = f.read()
+    crlf = b"\r\n" in raw_bytes
+
+    out_text = "".join(result)
+    with open(out_path, "w", encoding="utf-8", newline="\r\n" if crlf else "\n") as f:
+        f.write(out_text)
+
+    return filled, skipped
+
+
+def build_msgstr_lines(src_raw_lines: list[str], indent: str) -> list[str]:
+    """Reconstruct msgstr line(s) from source raw quoted strings."""
+    if not src_raw_lines:
+        return [f'msgstr ""\n']
+
+    first = src_raw_lines[0]
+    out = [f"msgstr {first}\n"]
+    for extra in src_raw_lines[1:]:
+        out.append(f"{extra}\n")
+    return out
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Import translations into a .po file without changing its layout.")
+    parser.add_argument("source", help="Source .po file (provides translations)")
+    parser.add_argument("target", help="Target .po file (receives translations)")
+    parser.add_argument("--out", help="Output path (default: overwrite target)")
+    parser.add_argument("--overwrite", action="store_true",
+                        help="Replace non-empty msgstr in target if source differs")
+    parser.add_argument("--use-fuzzy", action="store_true",
+                        help="Also import fuzzy entries from source")
+    args = parser.parse_args()
+
+    out_path = args.out or args.target
+
+    print(f"Parsing source: {args.source}")
+    source_entries = parse_po(args.source)
+    print(f"  {len(source_entries)} entries found")
+
+    print(f"Patching target: {args.target} -> {out_path}")
+    filled, skipped = rewrite_target(args.target, out_path, source_entries,
+                                     overwrite=args.overwrite,
+                                     use_fuzzy=args.use_fuzzy)
+    print(f"Done. Filled: {filled}, Skipped (already translated): {skipped}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tl/zh-TW.po
+++ b/tl/zh-TW.po
@@ -11,7 +11,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-07 14:46+0900\n"
-"PO-Revision-Date: 2026-06-07 16:58+0900\n"
+"PO-Revision-Date: 2026-06-07 17:32+0800\n"
 "Last-Translator: r888800009 <r888800009@gmail.com>\n"
 "Language-Team: Language zh-tw\n"
 "Language: zh_TW\n"
@@ -969,7 +969,7 @@ msgstr "助理"
 
 #: source/nijigenerate/panels/agent.d:370
 msgid "Assistant (thinking)"
-msgstr "助理（思考中）"
+msgstr "助理（啟用思考）"
 
 #: source/nijigenerate/panels/agent.d:371
 msgid "You (echo)"
@@ -983,11 +983,11 @@ msgstr "計畫"
 #: source/nijigenerate/panels/agent.d:375
 #, c-format, d-format
 msgid "Tool#%s"
-msgstr "工具 %s"
+msgstr "工具 %s"
 
 #: source/nijigenerate/panels/agent.d:375
 msgid "Tool"
-msgstr "工具"
+msgstr "工具"
 
 #: source/nijigenerate/panels/agent.d:376
 msgid "Command list"
@@ -1022,7 +1022,7 @@ msgstr "Deny"
 
 #: source/nijigenerate/panels/agent.d:1571
 msgid "Agent"
-msgstr "Agent"
+msgstr "代理式AI"
 
 #. controls (right aligned)
 #: source/nijigenerate/panels/agent.d:1594
@@ -1032,11 +1032,11 @@ msgstr "Status: %s"
 
 #: source/nijigenerate/panels/agent.d:1617
 msgid "New session"
-msgstr "New session"
+msgstr "新對話"
 
 #: source/nijigenerate/panels/agent.d:1702
 msgid "User message:"
-msgstr "使用者訊息："
+msgstr "使用者訊息："
 
 #: source/nijigenerate/panels/agent.d:1720
 msgid ""
@@ -1180,7 +1180,7 @@ msgstr "參數"
 
 #: source/nijigenerate/panels/resource.d:272
 msgid "Resources"
-msgstr "遮罩來源"
+msgstr "資源"
 
 #: source/nijigenerate/panels/inspector/common.d:361
 msgid "Select Value"
@@ -3944,7 +3944,7 @@ msgstr "顯示「匯入 Session 資料」對話框。"
 
 #: source/nijigenerate/commands/puppet/tool.d:41
 msgid "Import INP Session Data."
-msgstr "匯入 INP Session 資料。"
+msgstr "匯入 INP Session 資料。"
 
 #: source/nijigenerate/commands/puppet/tool.d:51
 msgid "Successfully overwrote Inochi Session tracking data..."
@@ -4055,7 +4055,7 @@ msgstr "新增"
 
 #: source/nijigenerate/commands/puppet/file.d:453
 msgid "Create new project."
-msgstr "新增專案"
+msgstr "新增專案"
 
 #: source/nijigenerate/commands/puppet/file.d:465
 msgid "Open"
@@ -4084,15 +4084,15 @@ msgstr "儲存"
 
 #: source/nijigenerate/commands/puppet/file.d:494
 msgid "Show \"Save\" dialog."
-msgstr "顯示「儲存」對話框。"
+msgstr "顯示「儲存」對話框。"
 
 #: source/nijigenerate/commands/puppet/file.d:506
 msgid "Save to file path"
-msgstr "儲存至檔案"
+msgstr "儲存至檔案"
 
 #: source/nijigenerate/commands/puppet/file.d:506
 msgid "Save puppet to specified file."
-msgstr "將模型儲存到指定檔案。"
+msgstr "將模型儲存到指定檔案。"
 
 #: source/nijigenerate/commands/puppet/file.d:519
 msgid "Show \"Save as\" dialog."
@@ -4100,31 +4100,31 @@ msgstr "顯示「儲存 as」對話框。"
 
 #: source/nijigenerate/commands/puppet/file.d:531
 msgid "Import Photoshop Document"
-msgstr "匯入 Photoshop 文件"
+msgstr "匯入 Photoshop 文件"
 
 #: source/nijigenerate/commands/puppet/file.d:531
 msgid "Show \"Import Photoshop Document\" dialog."
-msgstr "顯示「匯入 Photoshop 文件」對話框。"
+msgstr "顯示「匯入 Photoshop 文件」對話框。"
 
 #: source/nijigenerate/commands/puppet/file.d:549
 msgid "Import Photoshop Document from file path"
-msgstr "從檔案路徑匯入 Photoshop 文件"
+msgstr "從檔案路徑匯入 Photoshop 文件"
 
 #: source/nijigenerate/commands/puppet/file.d:549
 msgid "Import a PSD file without showing a dialog."
-msgstr "不顯示對話框匯入 PSD 檔案。"
+msgstr "不顯示對話框匯入 PSD 檔案。"
 
 #: source/nijigenerate/commands/puppet/file.d:568
 msgid "Import Krita Document"
-msgstr "匯入 Krita 文件"
+msgstr "匯入 Krita 文件"
 
 #: source/nijigenerate/commands/puppet/file.d:568
 msgid "Show \"Import Krita Document\" dialog."
-msgstr "顯示「匯入 Krita 文件」對話框。"
+msgstr "顯示「匯入 Krita 文件」對話框。"
 
 #: source/nijigenerate/commands/puppet/file.d:586
 msgid "Import Krita Document from file path"
-msgstr "從檔案路徑匯入 Krita 文件"
+msgstr "從檔案路徑匯入 Krita 文件"
 
 #: source/nijigenerate/commands/puppet/file.d:586
 msgid "Import a KRA file without showing a dialog."
@@ -4168,35 +4168,35 @@ msgstr "不顯示對話框匯入影像檔案夾。"
 
 #: source/nijigenerate/commands/puppet/file.d:672
 msgid "Merge Photoshop Document"
-msgstr "合併 Photoshop 文件"
+msgstr "合併 Photoshop 文件"
 
 #: source/nijigenerate/commands/puppet/file.d:672
 msgid "Show \"Merge Photoshop Document\" dialog."
-msgstr "顯示「合併 Photoshop 文件」對話框。"
+msgstr "顯示「合併 Photoshop 文件」對話框。"
 
 #: source/nijigenerate/commands/puppet/file.d:698
 msgid "Merge Photoshop Document from file path"
-msgstr "從檔案路徑合併 Photoshop 文件"
+msgstr "從檔案路徑合併 Photoshop 文件"
 
 #: source/nijigenerate/commands/puppet/file.d:698
 msgid "Merge a PSD file into the current puppet using default mapping."
-msgstr "使用預設對應將 PSD 檔案合併到目前模型。"
+msgstr "使用預設對應將 PSD 檔案合併到目前模型。"
 
 #: source/nijigenerate/commands/puppet/file.d:713
 msgid "Merge Krita Document"
-msgstr "合併 Krita 文件"
+msgstr "合併 Krita 文件"
 
 #: source/nijigenerate/commands/puppet/file.d:713
 msgid "Show \"Merge Krita Document\" dialog."
-msgstr "顯示「合併 Krita 文件」對話框。"
+msgstr "顯示「合併 Krita 文件」對話框。"
 
 #: source/nijigenerate/commands/puppet/file.d:739
 msgid "Merge Krita Document from file path"
-msgstr "從檔案路徑合併 Krita 文件"
+msgstr "從檔案路徑合併 Krita 文件"
 
 #: source/nijigenerate/commands/puppet/file.d:739
 msgid "Merge a KRA file into the current puppet using default mapping."
-msgstr "使用預設對應將 KRA 檔案合併到目前模型。"
+msgstr "使用預設對應將 KRA 檔案合併到目前模型。"
 
 #: source/nijigenerate/commands/puppet/file.d:754
 msgid "Merge Image Files"
@@ -4204,35 +4204,35 @@ msgstr "圖片檔案夾"
 
 #: source/nijigenerate/commands/puppet/file.d:754
 msgid "Show \"Merge image files\" dialog."
-msgstr "顯示「合併影像檔案」對話框。"
+msgstr "顯示「合併影像檔案」對話框。"
 
 #: source/nijigenerate/commands/puppet/file.d:781
 msgid "Merge Image Files from file paths"
-msgstr "從檔案路徑合併影像檔案"
+msgstr "從檔案路徑合併影像檔案"
 
 #: source/nijigenerate/commands/puppet/file.d:781
 msgid "Merge image files into the current puppet without showing a dialog."
-msgstr "不顯示對話框將影像檔案合併到目前模型。"
+msgstr "不顯示對話框將影像檔案合併到目前模型。"
 
 #: source/nijigenerate/commands/puppet/file.d:797
 msgid "Merge nijigenerate project"
-msgstr "nijigenerate 專案"
+msgstr "合併 nijigenerate 專案"
 
 #: source/nijigenerate/commands/puppet/file.d:797
 msgid "Show \"Merge nijilive puppet file\" dialog."
-msgstr "顯示「合併 nijilive 模型檔案」對話框。"
+msgstr "顯示「合併 nijilive 模型檔案」對話框。"
 
 #: source/nijigenerate/commands/puppet/file.d:822
 msgid "Merge nijigenerate project from file path"
-msgstr "合併其他 nijigenerate 專案"
+msgstr "合併其他 nijigenerate 專案"
 
 #: source/nijigenerate/commands/puppet/file.d:822
 msgid "Merge an INP project into the current puppet without showing a dialog."
-msgstr "不顯示對話框將 INP 專案合併到目前模型。"
+msgstr "不顯示對話框將 INP 專案合併到目前模型。"
 
 #: source/nijigenerate/commands/puppet/file.d:838
 msgid "Export nijilive puppet"
-msgstr "匯出 nijilive 模型"
+msgstr "匯出 nijilive 模型"
 
 #: source/nijigenerate/commands/puppet/file.d:838
 msgid "Show \"Export to nijilive puppet\" dialog."
@@ -4248,59 +4248,59 @@ msgstr "匯出…"
 
 #: source/nijigenerate/commands/puppet/file.d:863
 msgid "Export nijilive puppet to file path"
-msgstr "將 nijilive 模型匯出到檔案路徑"
+msgstr "將 nijilive 模型匯出到檔案路徑"
 
 #: source/nijigenerate/commands/puppet/file.d:863
 msgid "Export an INP file without showing a dialog."
-msgstr "不顯示對話框匯出 INP 檔案。"
+msgstr "不顯示對話框匯出 INP 檔案。"
 
 #: source/nijigenerate/commands/puppet/file.d:886
 msgid "Export PNG (*.png)"
-msgstr "匯出 PNG（*.png）"
+msgstr "匯出 PNG（*.png）"
 
 #: source/nijigenerate/commands/puppet/file.d:886
 msgid "Show \"Export to png image\" dialog."
-msgstr "顯示「匯出為 PNG 影像」對話框。"
+msgstr "顯示「匯出為 PNG 影像」對話框。"
 
 #: source/nijigenerate/commands/puppet/file.d:909
 msgid "Export PNG to file path"
-msgstr "將 PNG 匯出到檔案路徑"
+msgstr "將 PNG 匯出到檔案路徑"
 
 #: source/nijigenerate/commands/puppet/file.d:909
 msgid "Export a PNG image without showing a dialog."
-msgstr "不顯示對話框匯出 PNG 影像。"
+msgstr "不顯示對話框匯出 PNG 影像。"
 
 #: source/nijigenerate/commands/puppet/file.d:930
 msgid "Export JPEG (*.jpeg)"
-msgstr "匯出 JPEG（*.jpeg）"
+msgstr "匯出 JPEG（*.jpeg）"
 
 #: source/nijigenerate/commands/puppet/file.d:930
 msgid "Show \"Export to jpeg image\" dialog."
-msgstr "顯示「匯出為 JPEG 影像」對話框。"
+msgstr "顯示「匯出為 JPEG 影像」對話框。"
 
 #: source/nijigenerate/commands/puppet/file.d:953
 msgid "Export JPEG to file path"
-msgstr "將 JPEG 匯出到檔案路徑"
+msgstr "將 JPEG 匯出到檔案路徑"
 
 #: source/nijigenerate/commands/puppet/file.d:953
 msgid "Export a JPEG image without showing a dialog."
-msgstr "不顯示對話框匯出 JPEG 影像。"
+msgstr "不顯示對話框匯出 JPEG 影像。"
 
 #: source/nijigenerate/commands/puppet/file.d:974
 msgid "Export TARGA (*.tga)"
-msgstr "匯出 TARGA（*.tga）"
+msgstr "匯出 TARGA（*.tga）"
 
 #: source/nijigenerate/commands/puppet/file.d:974
 msgid "Show \"Export to TGA image\" dialog."
-msgstr "顯示「匯出為 TGA 影像」對話框。"
+msgstr "顯示「匯出為 TGA 影像」對話框。"
 
 #: source/nijigenerate/commands/puppet/file.d:997
 msgid "Export TGA to file path"
-msgstr "將 TGA 匯出到檔案路徑"
+msgstr "將 TGA 匯出到檔案路徑"
 
 #: source/nijigenerate/commands/puppet/file.d:997
 msgid "Export a TGA image without showing a dialog."
-msgstr "不顯示對話框匯出 TGA 影像。"
+msgstr "不顯示對話框匯出 TGA 影像。"
 
 #: source/nijigenerate/commands/puppet/file.d:1018
 msgid "Export Video"
@@ -4308,7 +4308,7 @@ msgstr "匯出影片"
 
 #: source/nijigenerate/commands/puppet/file.d:1018
 msgid "Show \"Export to video\" dialog."
-msgstr "顯示「匯出影片」對話框。"
+msgstr "顯示「匯出影片」對話框。"
 
 #: source/nijigenerate/commands/puppet/file.d:1054
 msgid "Export Video to file path"
@@ -5056,7 +5056,7 @@ msgstr "伺服器已停用。按下完成以套用。"
 
 #: source/nijigenerate/windows/settings.d:382
 msgid "Coding Agent (ACP)"
-msgstr "編碼代理(ACP)"
+msgstr "程式碼代理(ACP)"
 
 #: source/nijigenerate/windows/settings.d:391
 msgid "Command"

--- a/tl/zh-TW.po
+++ b/tl/zh-TW.po
@@ -627,7 +627,7 @@ msgstr "縮放"
 
 #: source/nijigenerate/viewport/vertex/mesheditor/tools/edgecutter.d:76
 msgid "Cut edges intersecting the line"
-msgstr "剪切与线相交的边"
+msgstr "剪切與直線相交的邊"
 
 #: source/nijigenerate/viewport/vertex/mesheditor/tools/edgecutter.d:76
 msgid "Drag Left Mouse"
@@ -1397,7 +1397,7 @@ msgstr "材質比例"
 #: source/nijigenerate/panels/inspector/pathdeform.d:354
 #: source/nijigenerate/commands/depth/bone.d:2420
 msgid "Preview Depth Bone Deform"
-msgstr "预览深度骨骼變形"
+msgstr "預覽深度骨骼變形"
 
 #: source/nijigenerate/panels/inspector/griddeform.d:240
 #: source/nijigenerate/panels/inspector/pathdeform.d:360
@@ -1785,7 +1785,7 @@ msgstr "分割"
 
 #: source/nijigenerate/panels/inspector/pathdeform.d:81
 msgid "Physics Type"
-msgstr "物理类型"
+msgstr "物理類型"
 
 #: source/nijigenerate/panels/inspector/pathdeform.d:85
 #: source/nijigenerate/panels/inspector/simplephysics.d:79
@@ -1995,7 +1995,7 @@ msgstr "移動"
 
 #: source/nijigenerate/panels/inspector/depthbone.d:84
 msgid "Allow Parent to Targets"
-msgstr "允许父级影响目標"
+msgstr "允許父層影響目標"
 
 #: source/nijigenerate/panels/inspector/depthbone.d:85
 msgid ""
@@ -2923,7 +2923,7 @@ msgstr "設定"
 
 #: source/nijigenerate/commands/viewport/control.d:47
 msgid "Reverted flip pairs"
-msgstr "已還原翻转配对"
+msgstr "已還原翻轉配對"
 
 #: source/nijigenerate/commands/viewport/control.d:78
 msgid "Toggle mirror view."
@@ -2955,7 +2955,7 @@ msgstr "列出已註冊的翻轉配對。"
 
 #: source/nijigenerate/commands/viewport/control.d:148
 msgid "Register a flip pair."
-msgstr "注册一个翻转配对。"
+msgstr "註冊翻轉配對。"
 
 #: source/nijigenerate/commands/viewport/control.d:164
 msgid "Register flip pairs by name pattern."
@@ -3024,12 +3024,12 @@ msgstr "%s 必須為 [x, y, z]"
 #: source/nijigenerate/commands/depth/bone.d:1494
 #, c-format, d-format
 msgid "Auto Refresh Depth Bone Deform: %s"
-msgstr "自动刷新深度骨骼變形：%s"
+msgstr "自動刷新深度骨骼變形：%s"
 
 #: source/nijigenerate/commands/depth/bone.d:1439
 #: source/nijigenerate/commands/depth/bone.d:1494
 msgid "Auto Refresh Depth Bone Deform"
-msgstr "自动刷新深度骨骼變形"
+msgstr "自動刷新深度骨骼變形"
 
 #: source/nijigenerate/commands/depth/bone.d:1693
 msgid "Create Depth Rig Root"
@@ -3159,7 +3159,7 @@ msgstr "取得深度骨骼影響規則"
 
 #: source/nijigenerate/commands/depth/bone.d:2388
 msgid "Get depth bone influence rule"
-msgstr "获取深度骨骼影响规则"
+msgstr "取得深度骨骼影響規則"
 
 #: source/nijigenerate/commands/depth/bone.d:2402
 msgid "Preview Depth Bone Influence"
@@ -3167,15 +3167,15 @@ msgstr "預覽深度骨骼影響"
 
 #: source/nijigenerate/commands/depth/bone.d:2402
 msgid "Preview depth bone influence"
-msgstr "预览深度骨骼影响"
+msgstr "預覽深度骨骼影響"
 
 #: source/nijigenerate/commands/depth/bone.d:2420
 msgid "Preview depth bone deformation"
-msgstr "预览深度骨骼變形"
+msgstr "預覽深度骨骼變形"
 
 #: source/nijigenerate/commands/depth/bone.d:2455
 msgid "Apply depth bone deformation to current key"
-msgstr "将深度骨骼變形套用到目前关键点"
+msgstr "將深度骨骼變形套用到目前關鍵點"
 
 #: source/nijigenerate/commands/depth/map.d:256
 msgid "List Depths"
@@ -3243,11 +3243,11 @@ msgstr "移除一個已儲存的深度操作"
 
 #: source/nijigenerate/commands/depth/map.d:385
 msgid "Move Depth Operation"
-msgstr "移动深度操作"
+msgstr "移動深度操作"
 
 #: source/nijigenerate/commands/depth/map.d:385
 msgid "Move one saved depth operation"
-msgstr "移动一个已儲存的深度操作"
+msgstr "移動一個已儲存的深度操作"
 
 #: source/nijigenerate/commands/depth/map.d:404
 msgid "Clear Depth Operations"
@@ -3348,7 +3348,7 @@ msgstr "Schema"
 
 #: source/nijigenerate/commands/automesh/config.d:137
 msgid "Get AutoMesh Values"
-msgstr "获取 AutoMesh 值"
+msgstr "取得 AutoMesh 值"
 
 #: source/nijigenerate/commands/automesh/config.d:137
 msgid "Show AutoMesh config values"
@@ -3412,7 +3412,7 @@ msgstr "設定 AutoMesh 設定（按處理器）"
 
 #: source/nijigenerate/commands/automesh/config.d:639
 msgid "Get Active AutoMesh"
-msgstr "获取目前 AutoMesh"
+msgstr "取得目前 AutoMesh"
 
 #: source/nijigenerate/commands/automesh/config.d:639
 msgid "Show active AutoMesh processor"
@@ -3436,7 +3436,7 @@ msgstr "套用目前 AutoMesh"
 
 #: source/nijigenerate/commands/automesh/config.d:666
 msgid "Apply active AutoMesh to targets"
-msgstr "将目前 AutoMesh 套用到目標"
+msgstr "將目前 AutoMesh 套用到目標"
 
 #: source/nijigenerate/commands/automesh/dynamic.d:38
 msgid "AutoMesh queued"
@@ -3468,7 +3468,7 @@ msgstr "正在取消..."
 #: source/nijigenerate/commands/automesh/dynamic.d:285
 #, c-format, d-format
 msgid "AutoMesh generated empty mesh for %s"
-msgstr "AutoMesh 为 %s 生成了空網格"
+msgstr "AutoMesh 為 %s 生成了空網格"
 
 #: source/nijigenerate/commands/automesh/dynamic.d:289
 #, c-format, d-format
@@ -4572,7 +4572,7 @@ msgstr "選取 綁定s (選用)"
 
 #: source/nijigenerate/windows/command_browser.d:718
 msgid "Key point (pick via controller), optional"
-msgstr "关键点（通过控制器选取，可选）"
+msgstr "關鍵點（透過控制器選取，可選）"
 
 #. Current label
 #: source/nijigenerate/windows/command_browser.d:727
@@ -4588,7 +4588,7 @@ msgstr "未選擇工具…"
 
 #: source/nijigenerate/windows/command_browser.d:763
 msgid "Click on controller to pick keypoint."
-msgstr "点击控制器以选取关键点。"
+msgstr "點擊控制器以選取關鍵點。"
 
 #: source/nijigenerate/windows/command_browser.d:773
 msgid "Field"
@@ -4608,7 +4608,7 @@ msgstr "成功為 true，失敗為 false。"
 
 #: source/nijigenerate/windows/command_browser.d:780
 msgid "Optional user-facing message."
-msgstr "可选的用户可见訊息。"
+msgstr "可選的使用者可見訊息。"
 
 #: source/nijigenerate/windows/command_browser.d:782
 msgid "Resource element type"

--- a/tl/zh-TW.po
+++ b/tl/zh-TW.po
@@ -3,21 +3,23 @@
 # This file is distributed under the same license as the PACKAGE package.
 # choushin <thect@protonmail.com>, 2022.
 # LovelyA72 <a72@luotianyi.pro>, 2022.
+# Richardn <rniu5@jh.edu>, 2024.
+# r888800009 <r888800009@gmail.com>, 2026.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-07 14:46+0900\n"
-"PO-Revision-Date: 2022-10-10 21:14+0800\n"
-"Last-Translator: LovelyA72 <a72@luotianyi.pro>\n"
+"PO-Revision-Date: 2026-06-07 16:58+0900\n"
+"Last-Translator: r888800009 <r888800009@gmail.com>\n"
 "Language-Team: Language zh-tw\n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.1.1\n"
+"Generated-By: Babel 2.16.0\n"
 
 #: source/nijigenerate/viewport/depth/tools/landmark.d:21
 msgid "󰓹"
@@ -160,11 +162,11 @@ msgstr "取消"
 
 #: source/nijigenerate/viewport/base.d:704
 msgid "Editing armed parameter..."
-msgstr "正在編輯已啟用參數..."
+msgstr "正在編輯開始錄製的參數"
 
 #: source/nijigenerate/viewport/base.d:704
 msgid "Editing base transform..."
-msgstr "正在編輯基礎變換..."
+msgstr "編輯位置"
 
 #: source/nijigenerate/viewport/common/mesheditor/package.d:287
 msgid "Reset selected"
@@ -200,7 +202,7 @@ msgstr "對齊像素"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/brush.d:276
 msgid "SHIFT"
-msgstr "SHIFT"
+msgstr "Shift 鍵"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/brush.d:277
 msgid "Select vertices"
@@ -208,7 +210,7 @@ msgstr "隱藏 頂點"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/brush.d:277
 msgid "ALT"
-msgstr "ALT"
+msgstr "Alt 鍵"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/brush.d:905
 msgid "Drag mode"
@@ -216,11 +218,11 @@ msgstr "映射模式"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/brush.d:915
 msgid "Flow mode"
-msgstr "流動模式"
+msgstr "流動模式"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/brush.d:945
 msgid "Brush Tool"
-msgstr "筆刷工具"
+msgstr "筆刷工具"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/brush.d:964
 msgid "Teacher"
@@ -258,7 +260,7 @@ msgstr "左鍵（x2）"
 #: source/nijigenerate/viewport/common/mesheditor/tools/bezierdeform.d:306
 #: source/nijigenerate/viewport/common/mesheditor/tools/bezierdeform.d:405
 msgid "Toggle locked point"
-msgstr "切換鎖定點"
+msgstr "鎖定/解鎖點"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/pathdeform.d:222
 #: source/nijigenerate/viewport/common/mesheditor/tools/bezierdeform.d:306
@@ -266,24 +268,24 @@ msgstr "切換鎖定點"
 #: source/nijigenerate/viewport/common/mesheditor/tools/lasso.d:155
 #: source/nijigenerate/viewport/common/mesheditor/tools/lasso.d:156
 msgid "Ctrl"
-msgstr "Ctrl"
+msgstr "Ctrl 鍵"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/pathdeform.d:223
 #: source/nijigenerate/viewport/common/mesheditor/tools/bezierdeform.d:307
 #: source/nijigenerate/viewport/common/mesheditor/tools/bezierdeform.d:406
 msgid "Move point along with the path"
-msgstr "沿路徑移動點"
+msgstr "沿著路徑移動點"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/pathdeform.d:223
 #: source/nijigenerate/viewport/common/mesheditor/tools/bezierdeform.d:307
 #: source/nijigenerate/viewport/common/mesheditor/tools/bezierdeform.d:406
 #: source/nijigenerate/viewport/common/mesheditor/tools/lasso.d:154
 msgid "Shift"
-msgstr "Shift"
+msgstr "Shift 鍵"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/pathdeform.d:419
 msgid "Define paths"
-msgstr "定義路徑"
+msgstr "定義路徑"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/pathdeform.d:430
 msgid "Transform path"
@@ -297,7 +299,7 @@ msgstr "訂為當前值"
 #: source/nijigenerate/viewport/common/mesheditor/tools/pathdeform.d:456
 #: source/nijigenerate/viewport/common/mesheditor/tools/bezierdeform.d:592
 msgid "Move points along the path"
-msgstr "沿路徑移動點"
+msgstr "沿著路徑移動頂點"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/pathdeform.d:463
 #: source/nijigenerate/viewport/common/mesheditor/tools/bezierdeform.d:599
@@ -318,15 +320,15 @@ msgstr "新增"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/point.d:103
 msgid "Ctrl+Left Mouse"
-msgstr "Ctrl+滑鼠左鍵"
+msgstr "Ctrl+左鍵"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/point.d:490
 msgid "Vertex Tool"
-msgstr "點工具"
+msgstr "頂點工具"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/point.d:506
 msgid "Auto connect vertices"
-msgstr "隱藏 頂點"
+msgstr "自動連接頂點"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/lasso.d:44
 msgid "Poly Lasso Selection Mode"
@@ -338,39 +340,39 @@ msgstr "一般套索選取模式"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/lasso.d:153
 msgid "Add Lasso Point"
-msgstr "新增套索点"
+msgstr "為不規則選擇加入頂點"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/lasso.d:154
 msgid "Additive Selection"
-msgstr "追加選取"
+msgstr "擴充選擇"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/lasso.d:155
 msgid "Inverse Selection"
-msgstr "反向選取"
+msgstr "反轉選取"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/lasso.d:156
 msgid "Remove Selection"
-msgstr "移除選取"
+msgstr "移除選取"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/lasso.d:157
 msgid "Delete Last Lasso Point"
-msgstr "刪除最后一个套索点"
+msgstr "刪除最後一個不規則選擇點"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/lasso.d:157
 msgid "Right Mouse"
-msgstr "左鍵"
+msgstr "右鍵"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/lasso.d:158
 msgid "Clear All Lasso Points"
-msgstr "清除所有套索點"
+msgstr "清除所有不規則選擇點"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/lasso.d:158
 msgid "ESC"
-msgstr "ESC"
+msgstr "Esc 鍵"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/lasso.d:253
 msgid "Lasso Selection"
-msgstr "套索選取"
+msgstr "套索選取"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/connect.d:37
 msgid "Connect/Disconnect"
@@ -382,11 +384,11 @@ msgstr "連接多個"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/connect.d:38
 msgid "Shift+Left Mouse"
-msgstr "Shift+滑鼠左鍵"
+msgstr "Shift+左鍵"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/connect.d:128
 msgid "Edge Tool"
-msgstr "邊緣工具"
+msgstr "邊緣工具"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/onetimedeform.d:759
 msgid "apply deform"
@@ -402,19 +404,19 @@ msgstr "路徑變形工具"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/grid.d:344
 msgid "Drag to define 2x2 mesh"
-msgstr "拖曳以定義 2x2 網格"
+msgstr "拖曳來定義一個 2x2 網格"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/grid.d:345
 msgid "Add/remove key points to axes"
-msgstr "在軸上新增/移除關鍵點"
+msgstr "在軸上加入/刪除關鍵點"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/grid.d:346
 msgid "Change key point position in the axis"
-msgstr "Change key point position in axis"
+msgstr "改變關鍵點在軸上的位置"
 
 #: source/nijigenerate/viewport/common/mesheditor/tools/grid.d:513
 msgid "Grid Vertex Tool"
-msgstr "點工具"
+msgstr "網格頂點工具"
 
 #: source/nijigenerate/viewport/model/deform.d:135
 #: source/nijigenerate/viewport/model/package.d:348
@@ -453,7 +455,7 @@ msgstr "顯示 定向工具"
 #. Set clear color
 #: source/nijigenerate/viewport/model/package.d:363
 msgid "COLOR"
-msgstr "COLOR"
+msgstr "顏色"
 
 #: source/nijigenerate/viewport/model/package.d:374
 #: source/nijigenerate/panels/parameters.d:130
@@ -462,11 +464,11 @@ msgstr "重設"
 
 #: source/nijigenerate/viewport/model/package.d:378
 msgid "Background Color"
-msgstr "背景顏色"
+msgstr "背景顏色"
 
 #: source/nijigenerate/viewport/model/package.d:382
 msgid "Gizmos"
-msgstr "Gizmos"
+msgstr "工具"
 
 #: source/nijigenerate/viewport/model/package.d:396
 msgid " Merge Mesh"
@@ -474,11 +476,11 @@ msgstr "合併"
 
 #: source/nijigenerate/viewport/model/package.d:396
 msgid " Copy Mesh"
-msgstr "複製網格資料"
+msgstr " 複製網格"
 
 #: source/nijigenerate/viewport/model/package.d:396
 msgid " Edit Mesh"
-msgstr "編輯網格"
+msgstr " 編輯網格"
 
 #: source/nijigenerate/viewport/model/package.d:405
 msgid "Merge Mesh Data"
@@ -505,11 +507,11 @@ msgstr "編輯網格"
 
 #: source/nijigenerate/viewport/model/package.d:449
 msgid "Z-Sort"
-msgstr "排列中"
+msgstr "Z 排序"
 
 #: source/nijigenerate/viewport/model/package.d:449
 msgid "Size-Sort"
-msgstr "依大小排序"
+msgstr "依大小排序"
 
 #: source/nijigenerate/viewport/model/package.d:459
 msgid "Focus Selected"
@@ -550,11 +552,11 @@ msgstr "三角定位點"
 #: source/nijigenerate/viewport/vertex/package.d:208
 #: source/nijigenerate/viewport/vertex/package.d:279
 msgid "Bake"
-msgstr "Bake"
+msgstr "生成"
 
 #: source/nijigenerate/viewport/vertex/package.d:215
 msgid "Bakes the triangulation, applying it to the mesh."
-msgstr "烘焙三角化並套用到網格。"
+msgstr "生成三角形分割策略，將其應用到網格上"
 
 #: source/nijigenerate/viewport/vertex/package.d:219
 msgid "Triangulation Options"
@@ -562,11 +564,11 @@ msgstr "三角定位選項"
 
 #: source/nijigenerate/viewport/vertex/package.d:285
 msgid "Bakes the auto mesh."
-msgstr "烘焙自動網格。"
+msgstr "烘焙自動網格"
 
 #: source/nijigenerate/viewport/vertex/package.d:289
 msgid "Auto Meshing Options"
-msgstr "自動網格選項"
+msgstr "自動網格選項"
 
 #: source/nijigenerate/viewport/vertex/package.d:309
 msgid "Are you sure?"
@@ -597,7 +599,7 @@ msgstr "Alpha 預覽"
 
 #: source/nijigenerate/viewport/vertex/automesh/grid.d:186
 msgid "Auto Segmentation"
-msgstr "文檔"
+msgstr "自動分割網格"
 
 #: source/nijigenerate/viewport/vertex/automesh/grid.d:187
 msgid "Mask threshold"
@@ -605,15 +607,15 @@ msgstr "閥值"
 
 #: source/nijigenerate/viewport/vertex/automesh/grid.d:200
 msgid "X Segments"
-msgstr "X Segments"
+msgstr "X 軸格點數"
 
 #: source/nijigenerate/viewport/vertex/automesh/grid.d:213
 msgid "Y Segments"
-msgstr "Y Segments"
+msgstr "Y 軸格點數"
 
 #: source/nijigenerate/viewport/vertex/automesh/grid.d:226
 msgid "Margin"
-msgstr "邊距"
+msgstr "邊距"
 
 #: source/nijigenerate/viewport/vertex/automesh/grid.d:241
 msgid "X Scale"
@@ -647,7 +649,7 @@ msgstr "settings.json 檔案已損毀。Nijigenerate 將載入預設設定。
 
 #: source/nijigenerate/core/settings.d:34
 msgid "The corrupted settings file has been moved to "
-msgstr "損毀的設定檔已移動到 "
+msgstr "損壞的設定檔已被儲存至 "
 
 #: source/nijigenerate/core/settings.d:35
 msgid ""
@@ -660,7 +662,7 @@ msgid ""
 "Error message: "
 msgstr ""
 "\n"
-"錯誤訊息："
+"錯誤訊息： "
 
 #. Also handle NFS or I/O errors
 #. Only reached for genuine early failures (before completion)
@@ -714,7 +716,7 @@ msgstr "(除錯模式)"
 
 #: source/nijigenerate/ext/nodes/excamera.d:132
 msgid "Warning: Camera size must be divisible by 2"
-msgstr "警告：攝影機尺寸必須能被 2 整除"
+msgstr "警告：相機長寬必須是 2 的倍數"
 
 #: source/nijigenerate/panels/parameters.d:124
 msgid "Unset"
@@ -799,7 +801,7 @@ msgstr "線性"
 #: source/nijigenerate/panels/parameters.d:210
 #: source/nijigenerate/panels/timeline.d:96
 msgid "Cubic"
-msgstr "Cubic"
+msgstr "立方"
 
 #: source/nijigenerate/panels/parameters.d:217
 msgid "Copy to"
@@ -815,7 +817,7 @@ msgstr "綁定"
 
 #: source/nijigenerate/panels/parameters.d:252
 msgid "Show all nodes"
-msgstr "顯示 邊界"
+msgstr "顯示所有節點"
 
 #: source/nijigenerate/panels/parameters.d:252
 msgid "Show only selected nodes"
@@ -835,7 +837,7 @@ msgstr "分割"
 
 #: source/nijigenerate/panels/parameters.d:401
 msgid "To 2D"
-msgstr "To 2D"
+msgstr "轉為二維參數"
 
 #: source/nijigenerate/panels/parameters.d:406
 #: source/nijigenerate/commands/parameter/paramedit.d:35
@@ -858,7 +860,7 @@ msgstr "鏡像自動填入"
 
 #: source/nijigenerate/panels/parameters.d:453
 msgid "Paste and Horizontal Flip"
-msgstr "貼上並水平翻轉"
+msgstr "貼上並水平翻轉"
 
 #: source/nijigenerate/panels/parameters.d:461
 msgid "Duplicate and Horizontal Flip"
@@ -896,7 +898,7 @@ msgstr "手臂參數"
 
 #: source/nijigenerate/panels/parameters.d:547
 msgid "Add Keyframe"
-msgstr "新增參數"
+msgstr "新增關鍵影格"
 
 #: source/nijigenerate/panels/parameters.d:551
 msgid "Copy Keyframe"
@@ -1138,7 +1140,7 @@ msgstr "模型"
 
 #: source/nijigenerate/panels/nodes.d:654
 msgid "Filter, search for specific nodes"
-msgstr "過濾、搜尋特定參數"
+msgstr "過濾、搜尋特定節點"
 
 #: source/nijigenerate/panels/nodes.d:699
 msgid "Delete selected nodes"
@@ -1162,11 +1164,11 @@ msgstr "節點"
 
 #: source/nijigenerate/panels/animlist.d:35
 msgid "Edit..."
-msgstr "編輯"
+msgstr "編輯..."
 
 #: source/nijigenerate/panels/animlist.d:74
 msgid "Animation List"
-msgstr "編輯動畫"
+msgstr "動畫列表"
 
 #: source/nijigenerate/panels/resource.d:247
 msgid "New Node"
@@ -1199,7 +1201,7 @@ msgstr "一般資訊"
 
 #: source/nijigenerate/panels/inspector/puppet.d:72
 msgid "Part Count"
-msgstr "Part Count"
+msgstr "組件計數"
 
 #: source/nijigenerate/panels/inspector/puppet.d:78
 #: source/nijigenerate/windows/command_browser.d:599
@@ -1308,7 +1310,7 @@ msgstr "變形"
 #: source/nijigenerate/panels/inspector/griddeform.d:39
 #: source/nijigenerate/panels/inspector/meshgroup.d:33
 msgid "Dynamic Deformation (slower)"
-msgstr "動態變形（較慢）"
+msgstr "動態變形（速度較慢）"
 
 #: source/nijigenerate/panels/inspector/griddeform.d:43
 msgid ""
@@ -1373,7 +1375,7 @@ msgstr "聚焦"
 #: source/nijigenerate/panels/inspector/pathdeform.d:247
 #: source/nijigenerate/windows/inpexport.d:258
 msgid "Preview"
-msgstr "預覽"
+msgstr "預覽"
 
 #: source/nijigenerate/panels/inspector/griddeform.d:132
 #: source/nijigenerate/panels/inspector/pathdeform.d:252
@@ -1443,7 +1445,7 @@ msgstr "儲存至檔案"
 #. Allow saving texture to file
 #: source/nijigenerate/panels/inspector/part.d:113
 msgid "Load from File"
-msgstr "儲存至檔案"
+msgstr "從檔案載入"
 
 #: source/nijigenerate/panels/inspector/part.d:120
 #: source/nijigenerate/io/psd.d:39 source/nijigenerate/io/kra.d:35
@@ -1501,7 +1503,7 @@ msgstr "色調（螢幕）"
 #: source/nijigenerate/panels/inspector/part.d:224
 #: source/nijigenerate/panels/inspector/part.d:631
 msgid "Emission Strength"
-msgstr "發光強度"
+msgstr "發光強度"
 
 #. Header for the Blending options for Parts
 #: source/nijigenerate/panels/inspector/part.d:238
@@ -1538,7 +1540,7 @@ msgstr "螢幕"
 #: source/nijigenerate/panels/inspector/composite.d:73
 #: source/nijigenerate/windows/inpexport.d:281
 msgid "Overlay"
-msgstr "Overlay"
+msgstr "疊加"
 
 #. Darken blending mode
 #: source/nijigenerate/panels/inspector/part.d:258
@@ -1573,7 +1575,7 @@ msgstr "線性加亮"
 #: source/nijigenerate/panels/inspector/composite.d:88
 #: source/nijigenerate/windows/inpexport.d:296
 msgid "Add (Glow)"
-msgstr "新增（發光）"
+msgstr "增亮"
 
 #. Color Burn blending mode
 #: source/nijigenerate/panels/inspector/part.d:273
@@ -1601,21 +1603,21 @@ msgstr "亮色主題"
 #: source/nijigenerate/panels/inspector/composite.d:100
 #: source/nijigenerate/windows/inpexport.d:308
 msgid "Subtract"
-msgstr "Subtract"
+msgstr "減去"
 
 #. Difference blending mode
 #: source/nijigenerate/panels/inspector/part.d:285
 #: source/nijigenerate/panels/inspector/composite.d:103
 #: source/nijigenerate/windows/inpexport.d:311
 msgid "Difference"
-msgstr "Difference"
+msgstr "差值"
 
 #. Exclusion blending mode
 #: source/nijigenerate/panels/inspector/part.d:288
 #: source/nijigenerate/panels/inspector/composite.d:106
 #: source/nijigenerate/windows/inpexport.d:314
 msgid "Exclusion"
-msgstr "Exclusion"
+msgstr "排除"
 
 #. Inverse blending mode
 #: source/nijigenerate/panels/inspector/part.d:291
@@ -1628,14 +1630,14 @@ msgstr "反轉"
 #: source/nijigenerate/panels/inspector/composite.d:110
 #: source/nijigenerate/windows/inpexport.d:318
 msgid "Inverts the color by a factor of the overlying color"
-msgstr "Inverts color a factor overlying color"
+msgstr "用上層顏色的一個係數來反轉顏色"
 
 #. Destination In blending mode
 #: source/nijigenerate/panels/inspector/part.d:295
 #: source/nijigenerate/panels/inspector/composite.d:113
 #: source/nijigenerate/windows/inpexport.d:321
 msgid "Destination In"
-msgstr "Destination In"
+msgstr "保留重疊部分的下層內容"
 
 #. Clip to Lower blending mode
 #: source/nijigenerate/panels/inspector/part.d:298
@@ -1837,24 +1839,24 @@ msgstr "指定將前一個擺錘的運動傳遞給下一個擺錘的程度。
 
 #: source/nijigenerate/panels/inspector/composite.d:245
 msgid "Propagate MeshGroup"
-msgstr "傳播 MeshGroup"
+msgstr "傳遞網格組"
 
 #: source/nijigenerate/panels/inspector/composite.d:251
 msgid "Allow ascendant MeshGroup to deform children of Composite"
-msgstr "允许上级 MeshGroup 變形 Composite 的子節點"
+msgstr "使位於父節點的網格組對合成節點的子節點進行變形"
 
 #: source/nijigenerate/panels/inspector/meshgroup.d:28
 #: source/nijigenerate/windows/settings.d:266
 msgid "MeshGroup"
-msgstr "MeshGroup"
+msgstr "網格組"
 
 #: source/nijigenerate/panels/inspector/meshgroup.d:37
 msgid ""
 "Whether the MeshGroup should dynamically deform children,\n"
 "this is an expensive operation and should not be overused."
 msgstr ""
-"MeshGroup 是否要動態變形子節點，\n"
-"這是成本較高的操作，不應過度使用。"
+"是否令該網格組對子節點進行動態變形\n"
+"這是一個對性能需求大的操作，不應被過度使用"
 
 #: source/nijigenerate/panels/inspector/meshgroup.d:39
 msgid "Translate origins"
@@ -1862,7 +1864,7 @@ msgstr "移動"
 
 #: source/nijigenerate/panels/inspector/meshgroup.d:43
 msgid "Translate origin of child nodes for non-Drawable object."
-msgstr "平移非 Drawable 物件子節點的原點。"
+msgstr "平移非繪製物件的子節點的原點"
 
 #: source/nijigenerate/panels/inspector/drawable.d:30
 msgid "Drawable"
@@ -1884,7 +1886,7 @@ msgstr "取消映射"
 
 #: source/nijigenerate/panels/inspector/simplephysics.d:48
 msgid "Unassigned"
-msgstr "（未指派）"
+msgstr "（未指派）"
 
 #. ===== Parameters =====
 #: source/nijigenerate/panels/inspector/simplephysics.d:54
@@ -1895,7 +1897,7 @@ msgstr "參數"
 
 #: source/nijigenerate/panels/inspector/simplephysics.d:55
 msgid "(unassigned)"
-msgstr "（未指派）"
+msgstr "（未指派）"
 
 #: source/nijigenerate/panels/inspector/simplephysics.d:75
 #: source/nijigenerate/windows/command_browser.d:600
@@ -1922,7 +1924,7 @@ msgstr "長度"
 
 #: source/nijigenerate/panels/inspector/simplephysics.d:118
 msgid "YX"
-msgstr "YX"
+msgstr "YX"
 
 #: source/nijigenerate/panels/inspector/simplephysics.d:135
 msgid "Local Transform Lock"
@@ -1932,7 +1934,7 @@ msgstr "變形"
 msgid ""
 "Whether the physics system only listens to the movement of the physics node "
 "itself"
-msgstr "物理系統是否只監聽物理節點本身的移動"
+msgstr "物理系統是否只監聽物理節點本身的移動"
 
 #: source/nijigenerate/panels/inspector/simplephysics.d:155
 #: source/nijigenerate/panels/inspector/simplephysics.d:270
@@ -2070,7 +2072,7 @@ msgstr "對齊像素"
 #: source/nijigenerate/panels/inspector/node.d:226
 #: source/nijigenerate/panels/inspector/node.d:391
 msgid "Sorting"
-msgstr "排列中"
+msgstr "排列"
 
 #: source/nijigenerate/panels/logger.d:26
 msgid "Logger"
@@ -2122,7 +2124,7 @@ msgstr "插值模式"
 
 #: source/nijigenerate/panels/timeline.d:90
 msgid "Stepped"
-msgstr "Stepped"
+msgstr "階梯"
 
 #: source/nijigenerate/panels/timeline.d:102
 msgid "Merge Mode"
@@ -2131,7 +2133,7 @@ msgstr "合併"
 #: source/nijigenerate/panels/timeline.d:106
 #: source/nijigenerate/windows/editanim.d:87
 msgid "Additive"
-msgstr "Additive"
+msgstr "疊加"
 
 #: source/nijigenerate/panels/timeline.d:109
 msgid "Multiplicative"
@@ -2139,15 +2141,15 @@ msgstr "複製"
 
 #: source/nijigenerate/panels/timeline.d:114
 msgid "Forced"
-msgstr "Forced"
+msgstr "強制"
 
 #: source/nijigenerate/panels/timeline.d:224
 msgid "Lock playback to animation framerate"
-msgstr "Lock playback animation framerate"
+msgstr "鎖播放影格率到動畫影格率"
 
 #: source/nijigenerate/panels/timeline.d:294
 msgid "Not in Animation Edit mode..."
-msgstr "未開啟測試模式…"
+msgstr "未開啟動畫編輯模式…"
 
 #: source/nijigenerate/panels/timeline.d:301
 msgid "Timeline"
@@ -2164,7 +2166,7 @@ msgstr "使視圖符合模型"
 
 #: source/nijigenerate/panels/viewport.d:340
 msgid "Mirror View"
-msgstr "鏡像"
+msgstr "鏡像顯示"
 
 #: source/nijigenerate/panels/viewport.d:349
 msgid "Onion slice"
@@ -2184,11 +2186,11 @@ msgstr "重設物理"
 
 #: source/nijigenerate/panels/viewport.d:385
 msgid "Reset parameters"
-msgstr "重設參數"
+msgstr "重設參數"
 
 #: source/nijigenerate/panels/viewport.d:394
 msgid "Configure Flip Pairings"
-msgstr "設定"
+msgstr "設定翻轉配對"
 
 #. Removing unused pairs (happens when target nodes are removed.)
 #: source/nijigenerate/panels/viewport.d:403
@@ -2210,9 +2212,9 @@ msgid ""
 "\n"
 "You can change the default behaviour in the settings."
 msgstr ""
-"是否保留匯入檔案的資料夾結構？\n"
+"您希望同時匯入檔案中的圖層結構嗎？\n"
 "\n"
-"你可以在設定中變更預設行為。"
+"您可以在設定中更改預設的匯入選項。"
 
 #: source/nijigenerate/io/inimport.d:265 source/nijigenerate/project.d:468
 msgid "Import failed..."
@@ -2234,7 +2236,7 @@ msgstr "自動選取"
 #. If this is executed it's a bug, using enforce here to prevent infinite loop.
 #: source/nijigenerate/io/inpexport.d:414
 msgid "A texture is too big for the atlas."
-msgstr "A texture is too big atlas."
+msgstr "有一個過大的紋理無法被放入圖集。"
 
 #: source/nijigenerate/io/save.d:32 source/nijigenerate/windows/welcome.d:226
 msgid "Open..."
@@ -2251,7 +2253,7 @@ msgstr "另存新檔…"
 
 #: source/nijigenerate/io/save.d:89 source/nijigenerate/windows/settings.d:243
 msgid "Always ask"
-msgstr "一律詢問"
+msgstr "一律詢問"
 
 #: source/nijigenerate/io/save.d:90
 msgid "Don't save"
@@ -2274,7 +2276,7 @@ msgstr ""
 #. incViewportPresentMode(editMode_);
 #: source/nijigenerate/project.d:269
 msgid "New Project"
-msgstr "關閉 專案"
+msgstr "建立新專案"
 
 #: source/nijigenerate/project.d:327
 #, c-format, d-format
@@ -2283,7 +2285,7 @@ msgid ""
 "\n"
 "%s"
 msgstr ""
-"請將此檔案回報給開發者：\n"
+"請向開發人員回報此檔案：\n"
 "\n"
 "%s"
 
@@ -2521,13 +2523,13 @@ msgstr "%s 的深度操作已變更"
 #: source/nijigenerate/actions/mesh.d:71
 #, c-format, d-format
 msgid "Mesh %s change is restored."
-msgstr "網格 %s 的變更已還原。"
+msgstr "網格 %s 的變更已還原。"
 
 #: source/nijigenerate/actions/vertex.d:97
 #: source/nijigenerate/actions/mesh.d:78
 #, c-format, d-format
 msgid "Mesh %s was edited."
-msgstr "已輸出 %s ..."
+msgstr "網格 %s 已編輯"
 
 #: source/nijigenerate/actions/vertex.d:183
 #: source/nijigenerate/actions/vertex.d:191
@@ -2539,7 +2541,7 @@ msgstr "已輸出 %s ..."
 #: source/nijigenerate/actions/mesh.d:277
 #, c-format, d-format
 msgid "%s: vertex was translated."
-msgstr "%s：頂點已平移。"
+msgstr "%s: 頂點已被移動"
 
 #: source/nijigenerate/actions/vertex.d:348
 msgid "removed"
@@ -2625,7 +2627,7 @@ msgstr "已更改 %s 的可繪製網格"
 #: source/nijigenerate/actions/drawable.d:97
 #, c-format, d-format
 msgid "Drawable %s was changed"
-msgstr "已變更可繪製 %s"
+msgstr "可繪製 %s 已修改"
 
 #: source/nijigenerate/actions/deformable.d:88
 #, c-format, d-format
@@ -2717,13 +2719,13 @@ msgstr "將 %s 的類型還原為 %s"
 #: source/nijigenerate/actions/node.d:634
 #, c-format, d-format
 msgid "%s is added to mask of %s"
-msgstr "已將 %s 新增到 %s 的遮罩"
+msgstr "已將 %s 新增到 %s 的遮罩"
 
 #: source/nijigenerate/actions/node.d:626
 #: source/nijigenerate/actions/node.d:633
 #, c-format, d-format
 msgid "%s is deleted from mask of %s"
-msgstr "已從 %s 的遮罩中刪除 %s"
+msgstr "已從 %s 的遮罩中刪除 %s"
 
 #: source/nijigenerate/actions/node.d:690
 #, c-format, d-format
@@ -3934,7 +3936,7 @@ msgstr "Convert To %s"
 #: source/nijigenerate/commands/puppet/tool.d:20
 #: source/nijigenerate/commands/puppet/tool.d:41
 msgid "Import Inochi Session Data"
-msgstr "匯入 Inochi Session 資料"
+msgstr "匯入 Inochi Session 資料"
 
 #: source/nijigenerate/commands/puppet/tool.d:20
 msgid "Shows \"Import Session Data\" dialog."
@@ -3946,11 +3948,11 @@ msgstr "匯入 INP Session 資料。"
 
 #: source/nijigenerate/commands/puppet/tool.d:51
 msgid "Successfully overwrote Inochi Session tracking data..."
-msgstr "已成功覆寫 Inochi Session 追蹤資料..."
+msgstr "成功覆蓋 Inochi Session 追蹤資料"
 
 #: source/nijigenerate/commands/puppet/tool.d:55
 msgid "There was no Inochi Session data to import!"
-msgstr "There was no Inochi Session data import!"
+msgstr "沒有可匯入的 Inochi Session 資料"
 
 #: source/nijigenerate/commands/puppet/tool.d:67
 msgid "Premultiply textures"
@@ -3970,7 +3972,7 @@ msgstr "材質滲透..."
 
 #: source/nijigenerate/commands/puppet/tool.d:91
 msgid "Generate Mipmaps..."
-msgstr "生成 Mipmap..."
+msgstr "生成 Mipmaps..."
 
 #: source/nijigenerate/commands/puppet/tool.d:91
 msgid "Generate mipmaps."
@@ -4242,7 +4244,7 @@ msgstr "顯示「匯出到 nijilive 模型」對話框。"
 #: source/nijigenerate/commands/puppet/file.d:982
 #: source/nijigenerate/commands/puppet/file.d:1029
 msgid "Export..."
-msgstr "輸出…"
+msgstr "匯出…"
 
 #: source/nijigenerate/commands/puppet/file.d:863
 msgid "Export nijilive puppet to file path"
@@ -4302,7 +4304,7 @@ msgstr "不顯示對話框匯出 TGA 影像。"
 
 #: source/nijigenerate/commands/puppet/file.d:1018
 msgid "Export Video"
-msgstr "輸出失敗…"
+msgstr "匯出影片"
 
 #: source/nijigenerate/commands/puppet/file.d:1018
 msgid "Show \"Export to video\" dialog."
@@ -4310,7 +4312,7 @@ msgstr "顯示「匯出影片」對話框。"
 
 #: source/nijigenerate/commands/puppet/file.d:1054
 msgid "Export Video to file path"
-msgstr "輸出失敗…"
+msgstr "匯出影片到檔案路徑"
 
 #: source/nijigenerate/commands/puppet/file.d:1054
 msgid "Export a video without showing a dialog."
@@ -4326,7 +4328,7 @@ msgstr "关闭目前模型專案。"
 
 #: source/nijigenerate/commands/puppet/view.d:24
 msgid "Reset Layout"
-msgstr "重設界面"
+msgstr "重設佈局"
 
 #: source/nijigenerate/commands/puppet/view.d:24
 msgid "Set default layout of panels."
@@ -4378,7 +4380,7 @@ msgstr "切換所選節點的 GPU 差异聚合。"
 #: source/nijigenerate/windows/imgexport.d:94
 #: source/nijigenerate/windows/videoexport.d:171
 msgid "Export Settings"
-msgstr "輸出設定"
+msgstr "匯出設定"
 
 #: source/nijigenerate/windows/imgexport.d:111
 #: source/nijigenerate/windows/videoexport.d:188
@@ -4392,12 +4394,12 @@ msgstr "啟用後期處理"
 
 #: source/nijigenerate/windows/imgexport.d:138
 msgid "Export Image..."
-msgstr "輸出圖像…"
+msgstr "匯出圖像…"
 
 #: source/nijigenerate/windows/imgexport.d:145
 #: source/nijigenerate/windows/videoexport.d:316
 msgid "No cameras to export from in Scene, please add a Camera."
-msgstr "場景中沒有可匯出的攝影機，請新增攝影機。"
+msgstr "場景中沒有可匯出的攝影機，請新增攝影機。"
 
 #. Properties (inline)
 #: source/nijigenerate/windows/parameditor.d:170
@@ -4445,60 +4447,60 @@ msgstr "輸出比例"
 
 #: source/nijigenerate/windows/videoexport.d:194
 msgid "Animation"
-msgstr "編輯動畫"
+msgstr "動畫"
 
 #: source/nijigenerate/windows/videoexport.d:206
 #: source/nijigenerate/windows/inpexport.d:331
 msgid "Loops"
-msgstr "Loops"
+msgstr "循環次數"
 
 #: source/nijigenerate/windows/videoexport.d:207
 msgid "How many times the animation should loop"
-msgstr "動畫應循環的次數"
+msgstr "動畫應該循環的次數"
 
 #: source/nijigenerate/windows/videoexport.d:209
 #: source/nijigenerate/windows/editanim.d:97
 msgid "Framerate"
-msgstr "相機"
+msgstr "影格率"
 
 #: source/nijigenerate/windows/videoexport.d:212
 msgid "[AUTO]"
-msgstr "[AUTO]"
+msgstr "[ 自動 ]"
 
 #: source/nijigenerate/windows/videoexport.d:214
 msgid "Framerate of the video file"
-msgstr "影片檔案的影格率"
+msgstr "影片的影格率"
 
 #: source/nijigenerate/windows/videoexport.d:216
 msgid "Lock to Animation Framerate"
-msgstr "鎖定到動畫影格率"
+msgstr "鎖定影格率到動畫影格率"
 
 #: source/nijigenerate/windows/videoexport.d:218
 msgid "Codec"
-msgstr "Codec"
+msgstr "編碼"
 
 #: source/nijigenerate/windows/videoexport.d:248
 #: source/nijigenerate/windows/inpexport.d:366
 #: source/nijigenerate/widgets/mainmenu.d:129
 msgid "Export"
-msgstr "輸出"
+msgstr "匯出"
 
 #: source/nijigenerate/windows/videoexport.d:292
 #: source/nijigenerate/widgets/modal/nagscreen.d:118
 msgid "Close"
-msgstr "關閉"
+msgstr "關閉"
 
 #: source/nijigenerate/windows/videoexport.d:303
 msgid "Export Video..."
-msgstr "輸出失敗…"
+msgstr "匯出影片…"
 
 #: source/nijigenerate/windows/videoexport.d:306
 msgid "FFMPEG was not found, please install FFMPEG to export video."
-msgstr "找不到 FFMPEG，請安裝 FFMPEG 以匯出影片。"
+msgstr "沒有找到 FFMPEG，請安裝 FFMPEG 來匯出影片。"
 
 #: source/nijigenerate/windows/videoexport.d:324
 msgid "No animations are defined for this model, please add an animation."
-msgstr "此模型尚未定義動畫，請新增動畫。"
+msgstr "這個模型沒有動畫，請加入一個動畫。"
 
 #: source/nijigenerate/windows/paramsplit.d:83
 #, c-format, d-format
@@ -4520,27 +4522,27 @@ msgstr "分割參數"
 
 #: source/nijigenerate/windows/flipconfig.d:442
 msgid "<< Not assigned >>"
-msgstr "<< 未指派 >>"
+msgstr "<< 未指派 >>"
 
 #: source/nijigenerate/windows/flipconfig.d:504
 msgid "< Add new row >"
-msgstr "< 新增列 >"
+msgstr "< 加入新列 >"
 
 #: source/nijigenerate/windows/flipconfig.d:582
 msgid "Pair"
-msgstr "Pair"
+msgstr "配對"
 
 #: source/nijigenerate/windows/flipconfig.d:590
 msgid "Part 1"
-msgstr "組件"
+msgstr "組件 1"
 
 #: source/nijigenerate/windows/flipconfig.d:591
 msgid "Part 2"
-msgstr "組件"
+msgstr "組件 2"
 
 #: source/nijigenerate/windows/flipconfig.d:667
 msgid "Flip Pairing"
-msgstr "Flip Pairing"
+msgstr "對稱配對"
 
 #: source/nijigenerate/windows/command_browser.d:601
 msgid "Description"
@@ -4754,7 +4756,7 @@ msgstr "匯入 PSD…"
 
 #: source/nijigenerate/windows/welcome.d:243
 msgid "Import KRA..."
-msgstr "匯入…"
+msgstr "匯入 KRA…"
 
 #: source/nijigenerate/windows/welcome.d:255
 msgid "Recent Projects"
@@ -4774,7 +4776,7 @@ msgstr "官網"
 
 #: source/nijigenerate/windows/welcome.d:291
 msgid "Documentation"
-msgstr "文檔"
+msgstr "文件"
 
 #: source/nijigenerate/windows/welcome.d:327
 msgid "nijigenerate Start"
@@ -4786,19 +4788,19 @@ msgstr "編輯此檔案時 nijigenerate 意外關閉。"
 
 #: source/nijigenerate/windows/autosave.d:47
 msgid "Restore data from a backup?"
-msgstr "要從備份還原資料嗎？"
+msgstr "從備份中還原資料？"
 
 #: source/nijigenerate/windows/autosave.d:56
 msgid "Discard"
-msgstr "Discard"
+msgstr "丟棄"
 
 #: source/nijigenerate/windows/autosave.d:62
 msgid "Restore"
-msgstr "還原"
+msgstr "復原"
 
 #: source/nijigenerate/windows/autosave.d:73
 msgid "Restore Autosave"
-msgstr "還原自動儲存"
+msgstr "復原自動存檔"
 
 #: source/nijigenerate/windows/about.d:88
 msgid "Credits"
@@ -4812,36 +4814,36 @@ msgstr "關於"
 #: source/nijigenerate/windows/editanim.d:37
 #: source/nijigenerate/windows/editanim.d:47
 msgid "Invalid Name"
-msgstr "無效名稱"
+msgstr "無效名稱"
 
 #: source/nijigenerate/windows/editanim.d:38
 msgid "Name can not be empty!"
-msgstr "名稱不可為空！"
+msgstr "名稱不可為空！"
 
 #: source/nijigenerate/windows/editanim.d:48
 #, c-format, d-format
 msgid "%s is already taken! Please chose another animation name."
-msgstr "%s 已被使用！請選擇其他動畫名稱。"
+msgstr "%s 已存在。請選擇一個不同的動畫名稱。"
 
 #: source/nijigenerate/windows/editanim.d:86
 msgid "Options"
-msgstr "輸出選項"
+msgstr "選項"
 
 #: source/nijigenerate/windows/editanim.d:90
 msgid "Frames"
-msgstr "參數"
+msgstr "影格數"
 
 #: source/nijigenerate/windows/editanim.d:93
 msgid "Lead In"
-msgstr "Lead In"
+msgstr "循環前影格數"
 
 #: source/nijigenerate/windows/editanim.d:94
 msgid "Lead Out"
-msgstr "Lead Out"
+msgstr "循環後影格數"
 
 #: source/nijigenerate/windows/editanim.d:109
 msgid "Custom Framerate"
-msgstr "自訂影格率"
+msgstr "自訂影格率"
 
 #: source/nijigenerate/windows/editanim.d:116
 #, c-format, d-format
@@ -4850,32 +4852,32 @@ msgstr "%s 原先是 %s"
 
 #: source/nijigenerate/windows/editanim.d:136
 msgid "120 FPS"
-msgstr "120 FPS"
+msgstr "120 FPS"
 
 #: source/nijigenerate/windows/editanim.d:137
 msgid "60 FPS"
-msgstr "60 FPS"
+msgstr "60 FPS"
 
 #: source/nijigenerate/windows/editanim.d:138
 msgid "30 FPS"
-msgstr "30 FPS"
+msgstr "30 FPS"
 
 #: source/nijigenerate/windows/editanim.d:139
 msgid "25 FPS"
-msgstr "25 FPS"
+msgstr "25 FPS"
 
 #: source/nijigenerate/windows/editanim.d:140
 msgid "Custom Framrate"
-msgstr "Custom Framrate"
+msgstr "自訂影格率"
 
 #: source/nijigenerate/windows/editanim.d:154
 msgid "New Animation..."
-msgstr "編輯動畫"
+msgstr "新增動畫"
 
 #: source/nijigenerate/windows/editanim.d:167
 #, c-format, d-format
 msgid "Edit %s..."
-msgstr "編輯網格 %s"
+msgstr "編輯 %s..."
 
 #: source/nijigenerate/windows/settings.d:103
 #: source/nijigenerate/windows/settings.d:145
@@ -4893,7 +4895,7 @@ msgstr "渲染設定"
 
 #: source/nijigenerate/windows/settings.d:119
 msgid "File Handling"
-msgstr "File Handling"
+msgstr "檔案儲存與匯入"
 
 #: source/nijigenerate/windows/settings.d:123
 #: source/nijigenerate/windows/settings.d:643
@@ -4926,7 +4928,7 @@ msgstr "使用 OpenDyslexic 字體"
 
 #: source/nijigenerate/windows/settings.d:208
 msgid "Use the OpenDyslexic font for Latin text characters."
-msgstr "Use OpenDyslexic font Latin text characters."
+msgstr "使用 OpenDyslexic 字體來顯示拉丁文字"
 
 #: source/nijigenerate/windows/settings.d:214
 msgid "Enable triple buffer fallback"
@@ -4939,35 +4941,35 @@ msgstr "當三重緩衝不穩定時回退到雙重緩衝。"
 #: source/nijigenerate/windows/settings.d:224
 #: source/nijigenerate/widgets/mainmenu.d:73
 msgid "Autosaves"
-msgstr "自動重新取名"
+msgstr "自動儲存"
 
 #: source/nijigenerate/windows/settings.d:226
 msgid "Enable Autosaves"
-msgstr "啟用自動儲存"
+msgstr "啟用自動儲存"
 
 #: source/nijigenerate/windows/settings.d:231
 msgid "Save Interval (Minutes)"
-msgstr "儲存間隔（分鐘）"
+msgstr "自動儲存間隔（分鐘）"
 
 #: source/nijigenerate/windows/settings.d:236
 msgid "Maximum Autosaves"
-msgstr "最大自動儲存數"
+msgstr "最大自動儲存檔案數"
 
 #: source/nijigenerate/windows/settings.d:241
 msgid "Import behaviour"
-msgstr "匯入行為"
+msgstr "匯入行為"
 
 #: source/nijigenerate/windows/settings.d:244
 msgid "Preserve"
-msgstr "重設"
+msgstr "保留"
 
 #: source/nijigenerate/windows/settings.d:245
 msgid "Don't preserve"
-msgstr "不保留"
+msgstr "不保留"
 
 #: source/nijigenerate/windows/settings.d:251
 msgid "Preserve structure"
-msgstr "保留結構"
+msgstr "是否保留圖層結構"
 
 #: source/nijigenerate/windows/settings.d:262
 msgid "Layer group replacement"
@@ -5000,7 +5002,7 @@ msgstr "關閉專案時是否自動儲存變更？"
 
 #: source/nijigenerate/windows/settings.d:312
 msgid "Zoom Mode"
-msgstr "縮放模式"
+msgstr "縮放模式"
 
 #: source/nijigenerate/windows/settings.d:313
 msgid "To Screen Center"
@@ -5012,7 +5014,7 @@ msgstr "基準姿勢頭部位置"
 
 #: source/nijigenerate/windows/settings.d:320
 msgid "Zoom Speed"
-msgstr "Zoom Speed"
+msgstr "縮放速度"
 
 #: source/nijigenerate/windows/settings.d:327
 msgid "MCP Server"
@@ -5029,7 +5031,7 @@ msgstr "Host"
 #. Port input
 #: source/nijigenerate/windows/settings.d:352
 msgid "Port"
-msgstr "端口"
+msgstr "連接埠"
 
 #: source/nijigenerate/windows/settings.d:366
 msgid ""
@@ -5179,7 +5181,7 @@ msgstr "PSD 合併"
 
 #: source/nijigenerate/windows/inpexport.d:108
 msgid "Atlassing"
-msgstr "Atlassing"
+msgstr "紋理圖集化"
 
 #: source/nijigenerate/windows/inpexport.d:112
 msgid "Decoration"
@@ -5187,7 +5189,7 @@ msgstr "旋轉"
 
 #: source/nijigenerate/windows/inpexport.d:142
 msgid "Atlas Settings"
-msgstr "工具設定"
+msgstr "紋理圖集設定"
 
 #: source/nijigenerate/windows/inpexport.d:144
 msgid "Resolution"
@@ -5195,13 +5197,13 @@ msgstr "解析度"
 
 #: source/nijigenerate/windows/inpexport.d:160
 msgid "Non-linear Scaling"
-msgstr "非線性縮放"
+msgstr "非線性縮放"
 
 #: source/nijigenerate/windows/inpexport.d:161
 msgid ""
 "Whether too large parts should individually be scaled down instead of all "
 "parts being scaled down uniformly."
-msgstr "過大的部件是否應個別縮小，而不是將所有部件等比例縮小。"
+msgstr "是否單獨縮小太大的組件（而非統一縮小全部組件）"
 
 #: source/nijigenerate/windows/inpexport.d:164
 msgid "Texture Scale"
@@ -5209,28 +5211,28 @@ msgstr "材質比例"
 
 #: source/nijigenerate/windows/inpexport.d:170
 msgid "Padding"
-msgstr "Padding"
+msgstr "填充"
 
 #: source/nijigenerate/windows/inpexport.d:176
 msgid "Optimizations"
-msgstr "Optimizations"
+msgstr "最佳化"
 
 #: source/nijigenerate/windows/inpexport.d:178
 msgid "Prune unused nodes"
-msgstr "修剪未使用的節點"
+msgstr "清除未使用的節點"
 
 #: source/nijigenerate/windows/inpexport.d:179
 msgid "Prune nodes which have been disabled from the export."
-msgstr "修剪已從匯出停用的節點。"
+msgstr "清除已從匯出中禁用的節點"
 
 #: source/nijigenerate/windows/inpexport.d:195
 msgid "Watermark"
-msgstr "Watermark"
+msgstr "浮水印"
 
 #. Allow saving texture to file
 #: source/nijigenerate/windows/inpexport.d:202
 msgid "Load"
-msgstr "Load"
+msgstr "載入"
 
 #: source/nijigenerate/windows/inpexport.d:358
 msgid ""
@@ -5240,21 +5242,21 @@ msgstr "材質過大無法放入材質圖集，材質比例已被調降。"
 
 #: source/nijigenerate/windows/inpexport.d:377
 msgid "Export failed..."
-msgstr "輸出失敗…"
+msgstr "匯出失敗…"
 
 #: source/nijigenerate/windows/inpexport.d:386
 msgid "Export Options"
-msgstr "輸出選項"
+msgstr "匯出選項"
 
 #: source/nijigenerate/windows/kramerge.d:449
 msgid ""
 "Renames all mapped nodes to match the names of the KRA layer that was merged "
 "in to them."
-msgstr "重新命名所有以映射的節點已對應 PSD 圖層。"
+msgstr "重新命名所有以映射的節點已對應 KRA 圖層。"
 
 #: source/nijigenerate/windows/kramerge.d:496
 msgid "KRA Merging"
-msgstr "PSD 合併"
+msgstr "KRA 合併"
 
 #: source/nijigenerate/widgets/mainmenu.d:71
 msgid "Recent"
@@ -5270,7 +5272,7 @@ msgstr "匯入標準 Photoshop PSD 檔案。"
 
 #: source/nijigenerate/widgets/mainmenu.d:104
 msgid "Import a standard Krita KRA file."
-msgstr "匯入標準 Krita KRA 檔案。"
+msgstr "匯入標準 Krita KRA 檔案。"
 
 #: source/nijigenerate/widgets/mainmenu.d:107
 msgid "Import existing puppet file, editing options limited"
@@ -5286,11 +5288,11 @@ msgstr "合併 Photoshop 檔案圖層"
 
 #: source/nijigenerate/widgets/mainmenu.d:118
 msgid "Merge layers from Krita document"
-msgstr "合併 Krita 文件的圖層"
+msgstr "合併 Krita 檔案圖層"
 
 #: source/nijigenerate/widgets/mainmenu.d:121
 msgid "Merges (adds) selected image files to project"
-msgstr "將所選影像檔案合併（新增）到專案"
+msgstr "選擇圖片合併（加入）到專案中"
 
 #: source/nijigenerate/widgets/mainmenu.d:124
 msgid "Merge another nijigenerate project in to this one"
@@ -5323,7 +5325,7 @@ msgstr "ImGui 數據"
 
 #: source/nijigenerate/widgets/mainmenu.d:176
 msgid "ImGui Stack Tool"
-msgstr "ImGui 堆疊工具"
+msgstr "ImGui Stack 工具"
 
 #: source/nijigenerate/widgets/mainmenu.d:189
 msgid "Panels"
@@ -5331,7 +5333,7 @@ msgstr "面板"
 
 #: source/nijigenerate/widgets/mainmenu.d:207
 msgid "Panel is not visible in current edit mode."
-msgstr "面板在目前編輯模式中不可見。"
+msgstr "面板在目前編輯模式中不可見。"
 
 #: source/nijigenerate/widgets/mainmenu.d:215
 msgid "Configuration"
@@ -5382,13 +5384,13 @@ msgid ""
 "\n"
 "Only use this if your game engine can't use premultiplied alpha."
 msgstr ""
-"讓顏色延伸到完全透明的像素，以解決直通 Alpha 合成時的輪廓問題。\n"
+"使色彩滲出到透明像素上，以消除直通 alpha 渲染的白邊.\n"
 "\n"
-"僅在遊戲引擎無法使用預乘 Alpha 時使用。"
+"僅適用於不支援預乘 alpha 的遊戲引擎."
 
 #: source/nijigenerate/widgets/mainmenu.d:260
 msgid "Regenerates the puppet's mipmaps."
-msgstr "重新生成模型 Mipmap。"
+msgstr "重新生成模型 Mipmaps。"
 
 #: source/nijigenerate/widgets/mainmenu.d:263
 msgid "Generates fake layer info based on node names"
@@ -5450,7 +5452,7 @@ msgstr ""
 
 #: source/app.d:161
 msgid "Warning!"
-msgstr "警告！"
+msgstr "警告！"
 
 #: source/app.d:162
 msgid ""

--- a/tl/zh-TW.po
+++ b/tl/zh-TW.po
@@ -1148,7 +1148,7 @@ msgstr "未選擇工具…"
 
 #: source/nijigenerate/panels/nodes.d:705
 msgid "Reverse Node Order"
-msgstr "反转節點顺序"
+msgstr "反轉節點順序"
 
 #: source/nijigenerate/panels/nodes.d:711
 msgid "Follow Selection"
@@ -1357,7 +1357,7 @@ msgstr "沒有 DepthRigRoot。"
 #: source/nijigenerate/panels/inspector/pathdeform.d:226
 #: source/nijigenerate/panels/inspector/depthbone.d:26
 msgid "Add Standard Skeleton"
-msgstr "新增标准骨架"
+msgstr "新增標準骨架"
 
 #: source/nijigenerate/panels/inspector/griddeform.d:112
 #: source/nijigenerate/panels/inspector/pathdeform.d:232
@@ -2885,7 +2885,7 @@ msgstr "插入節點"
 #: source/nijigenerate/commands/viewport/palette.d:105
 #: source/nijigenerate/windows/settings.d:701
 msgid "Convert Node"
-msgstr "转换節點"
+msgstr "轉換節點"
 
 #. Inspector Panel
 #: source/nijigenerate/commands/viewport/palette.d:107
@@ -2935,7 +2935,7 @@ msgstr "切換洋蔥皮叠加顯示。"
 
 #: source/nijigenerate/commands/viewport/control.d:96
 msgid "Toggle physics drivers."
-msgstr "切換物理驱动。"
+msgstr "切換物理驅動。"
 
 #: source/nijigenerate/commands/viewport/control.d:105
 msgid "Toggle post processing."
@@ -2971,7 +2971,7 @@ msgstr "開啟設定資料夾"
 
 #: source/nijigenerate/commands/viewport/control.d:205
 msgid "Open Automesh Batching modal."
-msgstr "開啟 AutoMesh 批处理對話框。"
+msgstr "開啟 AutoMesh 批次處理對話框。"
 
 #: source/nijigenerate/commands/viewport/control.d:214
 msgid "Reset viewport zoom to 1.0."
@@ -2997,7 +2997,7 @@ msgstr "新增編輯器深度操作"
 
 #: source/nijigenerate/commands/depth/editor.d:42
 msgid "Add one in-progress depth operation"
-msgstr "新增一个进行中的深度操作"
+msgstr "新增一個進行中的深度操作"
 
 #: source/nijigenerate/commands/depth/editor.d:76
 msgid "Update Editor Depth Operation"
@@ -3049,11 +3049,11 @@ msgstr "建立 DepthBone 節點"
 
 #: source/nijigenerate/commands/depth/bone.d:1732
 msgid "Add Standard Depth Skeleton"
-msgstr "新增标准深度骨架"
+msgstr "新增標準深度骨架"
 
 #: source/nijigenerate/commands/depth/bone.d:1732
 msgid "Create standard depth bone hierarchy"
-msgstr "建立标准深度骨骼层级"
+msgstr "建立標準深度骨骼層級"
 
 #: source/nijigenerate/commands/depth/bone.d:2063
 #, c-format, d-format
@@ -3067,7 +3067,7 @@ msgstr "新增標準深度參數"
 
 #: source/nijigenerate/commands/depth/bone.d:2094
 msgid "Create standard face/body parameters and depth bone bindings"
-msgstr "建立标准面部/身体參數和深度骨骼綁定"
+msgstr "建立標準面部/身體參數和深度骨骼綁定"
 
 #: source/nijigenerate/commands/depth/bone.d:2106
 #, c-format, d-format
@@ -3095,7 +3095,7 @@ msgstr "設定深度骨骼靜止姿態"
 
 #: source/nijigenerate/commands/depth/bone.d:2199
 msgid "Set rest pose for a depth bone"
-msgstr "設定深度骨骼的静止姿态"
+msgstr "設定深度骨骼的靜止姿態"
 
 #: source/nijigenerate/commands/depth/bone.d:2220
 msgid "Set Depth Bone Constraint"
@@ -3223,7 +3223,7 @@ msgstr "新增深度操作"
 
 #: source/nijigenerate/commands/depth/map.d:326
 msgid "Add one saved depth operation"
-msgstr "新增一个已儲存的深度操作"
+msgstr "新增一個已儲存的深度操作"
 
 #: source/nijigenerate/commands/depth/map.d:349
 msgid "Update Depth Operation"
@@ -3428,7 +3428,7 @@ msgstr "設定目前 AutoMesh"
 
 #: source/nijigenerate/commands/automesh/config.d:654
 msgid "Activate AutoMesh processor"
-msgstr "激活 AutoMesh 處理器"
+msgstr "啟用 AutoMesh 處理器"
 
 #: source/nijigenerate/commands/automesh/config.d:666
 msgid "Apply Active AutoMesh"
@@ -3473,7 +3473,7 @@ msgstr "AutoMesh 為 %s 生成了空網格"
 #: source/nijigenerate/commands/automesh/dynamic.d:289
 #, c-format, d-format
 msgid "AutoMesh generated too few drawable vertices for %s"
-msgstr "AutoMesh 为 %s 生成的可繪製頂點过少"
+msgstr "AutoMesh 為 %s 生成的可繪製頂點過少"
 
 #: source/nijigenerate/commands/binding/binding.d:102
 msgid "Unset Key Frame"
@@ -3543,7 +3543,7 @@ msgstr "設定變形綁定"
 
 #: source/nijigenerate/commands/model/set_deform_binding.d:269
 msgid "Set deform binding offsets at current keypoint."
-msgstr "設定目前关键点的變形綁定偏移。"
+msgstr "設定目前關鍵點的變形綁定偏移。"
 
 #: source/nijigenerate/commands/model/set_deform_binding.d:429
 msgid "Set TRS Binding"
@@ -3553,7 +3553,7 @@ msgstr "綁定"
 msgid ""
 "Set node transform translation, rotation, and scale bindings at current "
 "keypoint."
-msgstr "設定目前关键点的節點變換平移、旋轉和縮放綁定。"
+msgstr "設定目前關鍵點的節點變換平移、旋轉和縮放綁定。"
 
 #: source/nijigenerate/commands/view/panel.d:10
 msgid "Toggle visibility of the specified panel"
@@ -3682,7 +3682,7 @@ msgstr ""
 
 #: source/nijigenerate/commands/parameter/paramedit.d:378
 msgid "Set Armed Parameter and Keypoint"
-msgstr "設定已啟用參數和关键点"
+msgstr "設定已啟用參數和關鍵點"
 
 #: source/nijigenerate/commands/parameter/paramedit.d:379
 msgid ""
@@ -3697,7 +3697,7 @@ msgstr ""
 
 #: source/nijigenerate/commands/parameter/paramedit.d:445
 msgid "Set the current parameter value as starting keyframe"
-msgstr "将目前參數值設定为起始關鍵影格"
+msgstr "將目前參數值設定為起始關鍵影格"
 
 #: source/nijigenerate/commands/parameter/animedit.d:60
 msgid "Animation: Add Keyframe"
@@ -3707,15 +3707,15 @@ msgstr "新增參數"
 msgid ""
 "Add a keyframe for the selected parameter in the active animation. Requires "
 "Animation Edit mode and an active animation."
-msgstr "为目前動畫中的所選參數新增關鍵影格。需要動畫編輯模式和目前動畫。"
+msgstr "為目前動畫中的所選參數新增關鍵影格。需要動畫編輯模式和目前動畫。"
 
 #: source/nijigenerate/commands/parameter/animedit.d:111
 msgid "Animation: Copy Keyframe"
-msgstr "動畫：复制關鍵影格"
+msgstr "動畫：複製關鍵影格"
 
 #: source/nijigenerate/commands/parameter/animedit.d:112
 msgid "Copy the selected parameter's keyframe at the current animation frame."
-msgstr "复制目前動畫影格中所選參數的關鍵影格。"
+msgstr "複製目前動畫影格中所選參數的關鍵影格。"
 
 #: source/nijigenerate/commands/parameter/animedit.d:137
 msgid "Animation: Paste Keyframe"
@@ -3725,7 +3725,7 @@ msgstr "編輯動畫"
 msgid ""
 "Paste copied animation keyframe values to the selected parameter at the "
 "current animation frame."
-msgstr "将复制的動畫關鍵影格值粘贴到目前動畫影格的所選參數。"
+msgstr "將複製的動畫關鍵影格值貼上到目前動畫影格的所選參數。"
 
 #: source/nijigenerate/commands/vertex/define_mesh.d:79
 msgid "Define Mesh"
@@ -3733,7 +3733,7 @@ msgstr "編輯網格"
 
 #: source/nijigenerate/commands/vertex/define_mesh.d:79
 msgid "Apply a mesh defined by vertices and indices to selected nodes."
-msgstr "将由頂點和索引定义的網格套用到所選節點。"
+msgstr "將由頂點和索引定義的網格套用到所選節點。"
 
 #: source/nijigenerate/commands/vertex/define_mesh.d:151
 msgid "Define Vertices"
@@ -3743,7 +3743,7 @@ msgstr "隱藏 頂點"
 msgid ""
 "Apply control vertices to selected Deformable nodes. Does not define "
 "triangle topology."
-msgstr "将控制頂點套用到所選可變形節點。不定义三角形拓扑。"
+msgstr "將控制頂點套用到所選可變形節點。不定義三角形拓撲。"
 
 #: source/nijigenerate/commands/vertex/define_mesh.d:197
 msgid "Define Grid"
@@ -3752,7 +3752,7 @@ msgstr "Define Grid"
 #: source/nijigenerate/commands/vertex/define_mesh.d:197
 msgid ""
 "Apply a rectangular grid defined by X/Y axes to selected GridDeformer nodes."
-msgstr "将由 X/Y 轴定义的矩形網格套用到所選 GridDeformer 節點。"
+msgstr "將由 X/Y 軸定義的矩形網格套用到所選 GridDeformer 節點。"
 
 #: source/nijigenerate/commands/node/welding.d:26
 msgid "Add Welding"
@@ -3818,7 +3818,7 @@ msgstr "分割參數"
 
 #: source/nijigenerate/commands/node/simplephysics.d:210
 msgid "Assign the parameter driven by the target SimplePhysics node"
-msgstr "分配由目標 SimplePhysics 節點驱动的參數"
+msgstr "分配由目標 SimplePhysics 節點驅動的參數"
 
 #: source/nijigenerate/commands/node/simplephysics.d:230
 msgid "Clear SimplePhysics Parameter"
@@ -3826,7 +3826,7 @@ msgstr "分割參數"
 
 #: source/nijigenerate/commands/node/simplephysics.d:230
 msgid "Unassign the parameter driven by the target SimplePhysics node"
-msgstr "取消分配由目標 SimplePhysics 節點驱动的參數"
+msgstr "取消分配由目標 SimplePhysics 節點驅動的參數"
 
 #: source/nijigenerate/commands/node/simplephysics.d:252
 msgid "Set SimplePhysics Model Type"
@@ -3856,12 +3856,12 @@ msgstr "設定 SimplePhysics 是否仅监听區域變換"
 #: source/nijigenerate/commands/node/node.d:29
 #, c-format, d-format
 msgid "Add Node %s under selection or root"
-msgstr "在所選项或根節點下新增節點 %s"
+msgstr "在所選項或根節點下新增節點 %s"
 
 #: source/nijigenerate/commands/node/node.d:55
 #, c-format, d-format
 msgid "Insert Node %s under parent of selection"
-msgstr "在所選项的父级下插入節點 %s"
+msgstr "在所選項的父層下插入節點 %s"
 
 #: source/nijigenerate/commands/node/node.d:81
 msgid "Move Node "
@@ -3877,7 +3877,7 @@ msgstr "未選擇工具… %s"
 #: source/nijigenerate/commands/node/dynamic.d:78
 #, c-format, d-format
 msgid "Nodes converted from %s"
-msgstr "已从 %s 转换節點"
+msgstr "已從 %s 轉換節點"
 
 #: source/nijigenerate/commands/node/node.d:121
 #: source/nijigenerate/commands/node/dynamic.d:78
@@ -4071,7 +4071,7 @@ msgstr "從檔案路徑開啟"
 
 #: source/nijigenerate/commands/puppet/file.d:477
 msgid "Open puppet from specified file."
-msgstr "从指定檔案開啟模型。"
+msgstr "從指定檔案開啟模型。"
 
 #: source/nijigenerate/commands/puppet/file.d:494
 #: source/nijigenerate/windows/imgexport.d:123
@@ -4092,7 +4092,7 @@ msgstr "儲存至檔案"
 
 #: source/nijigenerate/commands/puppet/file.d:506
 msgid "Save puppet to specified file."
-msgstr "将模型儲存到指定檔案。"
+msgstr "將模型儲存到指定檔案。"
 
 #: source/nijigenerate/commands/puppet/file.d:519
 msgid "Show \"Save as\" dialog."
@@ -4116,15 +4116,15 @@ msgstr "不顯示對話框匯入 PSD 檔案。"
 
 #: source/nijigenerate/commands/puppet/file.d:568
 msgid "Import Krita Document"
-msgstr "匯入 Krita 文档"
+msgstr "匯入 Krita 文件"
 
 #: source/nijigenerate/commands/puppet/file.d:568
 msgid "Show \"Import Krita Document\" dialog."
-msgstr "顯示「匯入 Krita 文档」對話框。"
+msgstr "顯示「匯入 Krita 文件」對話框。"
 
 #: source/nijigenerate/commands/puppet/file.d:586
 msgid "Import Krita Document from file path"
-msgstr "从檔案路徑匯入 Krita 文档"
+msgstr "從檔案路徑匯入 Krita 文件"
 
 #: source/nijigenerate/commands/puppet/file.d:586
 msgid "Import a KRA file without showing a dialog."
@@ -4140,7 +4140,7 @@ msgstr "顯示「匯入 nijilive 模型檔案」對話框。"
 
 #: source/nijigenerate/commands/puppet/file.d:627
 msgid "Import nijilive puppet from file path"
-msgstr "从檔案路徑匯入 nijilive 模型"
+msgstr "從檔案路徑匯入 nijilive 模型"
 
 #: source/nijigenerate/commands/puppet/file.d:627
 msgid "Import an INP file without showing a dialog."
@@ -4152,7 +4152,7 @@ msgstr "圖片檔案夾"
 
 #: source/nijigenerate/commands/puppet/file.d:643
 msgid "Show \"Import Image Folder\" dialog."
-msgstr "顯示「匯入影像檔案夹」對話框。"
+msgstr "顯示「匯入影像檔案夾」對話框。"
 
 #: source/nijigenerate/commands/puppet/file.d:647
 msgid "Select a Folder..."
@@ -4160,11 +4160,11 @@ msgstr "選擇檔案夾…"
 
 #: source/nijigenerate/commands/puppet/file.d:659
 msgid "Import Image Folder from file path"
-msgstr "从檔案路徑匯入影像檔案夹"
+msgstr "從檔案路徑匯入影像檔案夾"
 
 #: source/nijigenerate/commands/puppet/file.d:659
 msgid "Import a folder of image files without showing a dialog."
-msgstr "不顯示對話框匯入影像檔案夹。"
+msgstr "不顯示對話框匯入影像檔案夾。"
 
 #: source/nijigenerate/commands/puppet/file.d:672
 msgid "Merge Photoshop Document"
@@ -4180,23 +4180,23 @@ msgstr "從檔案路徑合併 Photoshop 文件"
 
 #: source/nijigenerate/commands/puppet/file.d:698
 msgid "Merge a PSD file into the current puppet using default mapping."
-msgstr "使用預設對應将 PSD 檔案合併到目前模型。"
+msgstr "使用預設對應將 PSD 檔案合併到目前模型。"
 
 #: source/nijigenerate/commands/puppet/file.d:713
 msgid "Merge Krita Document"
-msgstr "合併 Krita 文档"
+msgstr "合併 Krita 文件"
 
 #: source/nijigenerate/commands/puppet/file.d:713
 msgid "Show \"Merge Krita Document\" dialog."
-msgstr "顯示「合併 Krita 文档」對話框。"
+msgstr "顯示「合併 Krita 文件」對話框。"
 
 #: source/nijigenerate/commands/puppet/file.d:739
 msgid "Merge Krita Document from file path"
-msgstr "从檔案路徑合併 Krita 文档"
+msgstr "從檔案路徑合併 Krita 文件"
 
 #: source/nijigenerate/commands/puppet/file.d:739
 msgid "Merge a KRA file into the current puppet using default mapping."
-msgstr "使用預設對應将 KRA 檔案合併到目前模型。"
+msgstr "使用預設對應將 KRA 檔案合併到目前模型。"
 
 #: source/nijigenerate/commands/puppet/file.d:754
 msgid "Merge Image Files"
@@ -4208,11 +4208,11 @@ msgstr "顯示「合併影像檔案」對話框。"
 
 #: source/nijigenerate/commands/puppet/file.d:781
 msgid "Merge Image Files from file paths"
-msgstr "从檔案路徑合併影像檔案"
+msgstr "從檔案路徑合併影像檔案"
 
 #: source/nijigenerate/commands/puppet/file.d:781
 msgid "Merge image files into the current puppet without showing a dialog."
-msgstr "不顯示對話框将影像檔案合併到目前模型。"
+msgstr "不顯示對話框將影像檔案合併到目前模型。"
 
 #: source/nijigenerate/commands/puppet/file.d:797
 msgid "Merge nijigenerate project"
@@ -4228,7 +4228,7 @@ msgstr "合併其他 nijigenerate 專案"
 
 #: source/nijigenerate/commands/puppet/file.d:822
 msgid "Merge an INP project into the current puppet without showing a dialog."
-msgstr "不顯示對話框将 INP 專案合併到目前模型。"
+msgstr "不顯示對話框將 INP 專案合併到目前模型。"
 
 #: source/nijigenerate/commands/puppet/file.d:838
 msgid "Export nijilive puppet"
@@ -4248,7 +4248,7 @@ msgstr "匯出…"
 
 #: source/nijigenerate/commands/puppet/file.d:863
 msgid "Export nijilive puppet to file path"
-msgstr "将 nijilive 模型匯出到檔案路徑"
+msgstr "將 nijilive 模型匯出到檔案路徑"
 
 #: source/nijigenerate/commands/puppet/file.d:863
 msgid "Export an INP file without showing a dialog."
@@ -4260,11 +4260,11 @@ msgstr "匯出 PNG（*.png）"
 
 #: source/nijigenerate/commands/puppet/file.d:886
 msgid "Show \"Export to png image\" dialog."
-msgstr "顯示「匯出为 PNG 影像」對話框。"
+msgstr "顯示「匯出為 PNG 影像」對話框。"
 
 #: source/nijigenerate/commands/puppet/file.d:909
 msgid "Export PNG to file path"
-msgstr "将 PNG 匯出到檔案路徑"
+msgstr "將 PNG 匯出到檔案路徑"
 
 #: source/nijigenerate/commands/puppet/file.d:909
 msgid "Export a PNG image without showing a dialog."
@@ -4276,11 +4276,11 @@ msgstr "匯出 JPEG（*.jpeg）"
 
 #: source/nijigenerate/commands/puppet/file.d:930
 msgid "Show \"Export to jpeg image\" dialog."
-msgstr "顯示「匯出为 JPEG 影像」對話框。"
+msgstr "顯示「匯出為 JPEG 影像」對話框。"
 
 #: source/nijigenerate/commands/puppet/file.d:953
 msgid "Export JPEG to file path"
-msgstr "将 JPEG 匯出到檔案路徑"
+msgstr "將 JPEG 匯出到檔案路徑"
 
 #: source/nijigenerate/commands/puppet/file.d:953
 msgid "Export a JPEG image without showing a dialog."
@@ -4292,11 +4292,11 @@ msgstr "匯出 TARGA（*.tga）"
 
 #: source/nijigenerate/commands/puppet/file.d:974
 msgid "Show \"Export to TGA image\" dialog."
-msgstr "顯示「匯出为 TGA 影像」對話框。"
+msgstr "顯示「匯出為 TGA 影像」對話框。"
 
 #: source/nijigenerate/commands/puppet/file.d:997
 msgid "Export TGA to file path"
-msgstr "将 TGA 匯出到檔案路徑"
+msgstr "將 TGA 匯出到檔案路徑"
 
 #: source/nijigenerate/commands/puppet/file.d:997
 msgid "Export a TGA image without showing a dialog."
@@ -4324,7 +4324,7 @@ msgstr "關閉 專案"
 
 #: source/nijigenerate/commands/puppet/file.d:1180
 msgid "Close active puppet project."
-msgstr "关闭目前模型專案。"
+msgstr "關閉目前模型專案。"
 
 #: source/nijigenerate/commands/puppet/view.d:24
 msgid "Reset Layout"
@@ -4332,7 +4332,7 @@ msgstr "重設佈局"
 
 #: source/nijigenerate/commands/puppet/view.d:24
 msgid "Set default layout of panels."
-msgstr "設定面板預設布局。"
+msgstr "設定面板預設佈局。"
 
 #: source/nijigenerate/commands/puppet/view.d:36
 #: source/nijigenerate/commands/puppet/view.d:536
@@ -4564,7 +4564,7 @@ msgstr "選取參數（選用）"
 
 #: source/nijigenerate/windows/command_browser.d:714
 msgid "Select armed parameters (optional)"
-msgstr "選取已啟用參數（可选）"
+msgstr "選取已啟用參數（可選）"
 
 #: source/nijigenerate/windows/command_browser.d:716
 msgid "Select bindings (optional)"
@@ -4612,7 +4612,7 @@ msgstr "可選的使用者可見訊息。"
 
 #: source/nijigenerate/windows/command_browser.d:782
 msgid "Resource element type"
-msgstr "資源元素类型"
+msgstr "資源元素類型"
 
 #: source/nijigenerate/windows/command_browser.d:784
 msgid "Created/Deleted/Loaded (hint)"
@@ -5223,7 +5223,7 @@ msgstr "清除未使用的節點"
 
 #: source/nijigenerate/windows/inpexport.d:179
 msgid "Prune nodes which have been disabled from the export."
-msgstr "清除已從匯出中禁用的節點"
+msgstr "清除已從匯出中停用的節點"
 
 #: source/nijigenerate/windows/inpexport.d:195
 msgid "Watermark"

--- a/translation-validator.py
+++ b/translation-validator.py
@@ -1,0 +1,155 @@
+#/usr/bin/env python3
+import os
+import sys
+import glob
+import argparse
+
+from babel.messages.pofile import read_po
+
+"""
+# polib is broken, use babel instead
+# gettext not supported .po files
+
+pip install babel
+"""
+
+tl_files = glob.glob("tl/*.po")
+
+ignore = [
+    "tl/template.pot",
+]
+
+fmt_str_keywords = ['%s', '%d', '%f', '%u', '%lu']
+check_fuzzy = False
+ignore_empty = False
+
+def validate_string_formatting(msgid, msgstr) -> bool:
+    """
+    Check if the string formatting is correct
+    Note: currently not checking the order of the formatting, and not check %2$s etc
+    """
+    fmt_str_count = {}
+    fmt_target_count = {}
+    for fmt_str in fmt_str_keywords:
+        fmt_str_count[fmt_str] = msgid.count(fmt_str)
+        fmt_target_count[fmt_str] = msgstr.count(fmt_str)
+
+    for fmt_str in fmt_str_keywords:
+        if fmt_str_count[fmt_str] == 0:
+            continue
+        if fmt_str_count[fmt_str] != fmt_target_count[fmt_str]:
+            return False
+        
+    return True
+
+def validate_non_ascii(msgstr, msgid) -> bool:
+    """
+    For example, English using non-ascii as icon (Google Material Icons)
+    """
+    non_ascii = [c for c in msgid if ord(c) > 127]
+    non_ascii_target = [c for c in msgstr  if ord(c) > 127]
+    
+    for c in non_ascii:
+        if c not in non_ascii_target:
+            return False
+    
+    return True
+
+class ValidationError(Exception):
+    def __init__(self, message, entry):
+        self.message = message
+        self.entry = entry
+        
+    def __str__(self):
+        return self.message
+
+class Summary:
+    def __init__(self):
+        self.total = 0
+        self.success = 0
+
+    def print_summary(self):
+        print(f"Total: {self.total}, translated rate: {self.success}/{self.total} ({self.success/self.total*100:.2f}%)")
+
+def validate_string(entry, summary : Summary) -> bool:
+    summary.total += 1
+    if entry.string == "" and not ignore_empty:
+        raise ValidationError("msgstr is empty", entry)
+    
+    if not validate_string_formatting(entry.id, entry.string):
+        raise ValidationError("msgstr fmtstr is incorrect", entry)
+    
+    if not validate_non_ascii(entry.string, entry.id):
+        raise ValidationError("msgstr may lost icon", entry)
+
+    if entry.fuzzy and check_fuzzy:
+        raise ValidationError("msgstr is fuzzy", entry)
+
+    if not entry.fuzzy and entry.string != "":
+        summary.success += 1
+
+    return True
+
+escape_chars = {
+    "\n": "\\n", "\r": "\\r", "\t": "\\t",
+    "\"": "\\\""
+}
+escape_table = str.maketrans(escape_chars)
+
+def escape_string(s) -> str:
+    return s.translate(escape_table)
+
+def validate_file(file_path) -> int:
+    ret_code = 0
+    summary = Summary()
+    print("Validating file: " + file_path)
+
+    with open(file_path, 'r', encoding='utf-8') as file:
+        catalog = read_po(file)
+
+    for entry in catalog:
+        try:
+            validate_string(entry, summary)
+        except ValidationError as e:
+            msgid = escape_string(e.entry.id)
+            msgstr = escape_string(e.entry.string)
+            print("Validation Error: " + str(e) + f" ({file_path}:{e.entry.lineno})")
+            print(f"\tmsgid: \"{msgid}\"")
+            print(f"\tmsgstr: \"{msgstr}\"")
+            ret_code = 1
+
+    summary.print_summary()
+
+    return ret_code
+
+def validate_all() -> int:
+    ret_code = 0
+    for tl_file in tl_files:
+        ret_code += validate_file(tl_file)
+        
+    return ret_code
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Validate translation files')
+    parser.add_argument('-a', '--all', action='store_true', help='Validate all files')
+    parser.add_argument('-f', '--file', type=str, help='Validate specific file')
+    parser.add_argument('--fuzzy', action='store_true', help='Check fuzzy entries')
+    parser.add_argument('--ignore-empty', action='store_true', help='Ignore empty msgstr')
+    args = parser.parse_args()
+    
+    if args.fuzzy:
+        check_fuzzy = True
+        
+    if args.ignore_empty:
+        ignore_empty = True
+
+    if args.all:
+        sys.exit(validate_all())
+    elif args.file:
+        sys.exit(validate_file(args.file))
+    else:
+        print("No arguments given")
+        parser.print_help()
+        sys.exit(1)
+
+    

--- a/translation-validator.py
+++ b/translation-validator.py
@@ -10,7 +10,7 @@ from babel.messages.pofile import read_po
 # polib is broken, use babel instead
 # gettext not supported .po files
 
-pip install babel
+pip install babel opencc-python-reimplemented
 """
 
 tl_files = glob.glob("tl/*.po")
@@ -76,6 +76,9 @@ def validate_string(entry, summary : Summary) -> bool:
     if entry.string == "" and not ignore_empty:
         raise ValidationError("msgstr is empty", entry)
     
+    if entry.string.startswith('\ue894'):
+        raise ValidationError("msgstr contains untranslated marker (U+E894)", entry)
+
     if not validate_string_formatting(entry.id, entry.string):
         raise ValidationError("msgstr fmtstr is incorrect", entry)
     
@@ -98,6 +101,58 @@ escape_table = str.maketrans(escape_chars)
 
 def escape_string(s) -> str:
     return s.translate(escape_table)
+
+# ── Traditional Chinese checker ──────────────────────────────────────────────
+
+TRAD_CHECK_THRESHOLD = 0.15   # flag if fewer than 15% of CJK chars changed
+
+def _cjk_chars(s: str) -> list[str]:
+    """Return only the CJK unified ideograph characters in s."""
+    return [c for c in s if '\u4e00' <= c <= '\u9fff']
+
+def check_trad_file(file_path: str, threshold: float = TRAD_CHECK_THRESHOLD) -> None:
+    try:
+        import opencc
+    except ImportError:
+        print("opencc-python-reimplemented is required: pip install opencc-python-reimplemented")
+        sys.exit(1)
+
+    cc = opencc.OpenCC('tw2sp')
+    suspicious = []
+
+    with open(file_path, 'r', encoding='utf-8') as f:
+        catalog = read_po(f)
+
+    for entry in catalog:
+        msgstr = entry.string
+        if not msgstr:
+            continue
+
+        cjk = _cjk_chars(msgstr)
+        if len(cjk) < 3:       # too short to be meaningful
+            continue
+
+        converted = cc.convert(msgstr)
+        changed = sum(a != b for a, b in zip(msgstr, converted) if '\u4e00' <= a <= '\u9fff')
+        ratio = changed / len(cjk)
+
+        if ratio < threshold:
+            suspicious.append((entry, ratio, converted))
+
+    if not suspicious:
+        print(f"{file_path}: all entries pass zh-TW locale consistency check.")
+        return
+
+    print(f"\n{'='*60}")
+    print(f"Entries that may not follow zh-TW locale and phrasing conventions: {file_path}")
+    print(f"(detected low rate of expected zh-TW orthographic variation: < {threshold*100:.0f}%)")
+    print(f"{'='*60}")
+    for entry, ratio, converted in suspicious:
+        print(f"  Line {entry.lineno}  [Variation rate: {ratio*100:.0f}%]")
+        print(f"    msgid:     {escape_string(entry.id)}")
+        print(f"    msgstr:    {escape_string(entry.string)}")
+        print(f"    reference: {escape_string(converted)}")
+        print()
 
 @functools.lru_cache
 def load_template_msgid() -> set:
@@ -165,6 +220,10 @@ if __name__ == "__main__":
     parser.add_argument('-f', '--file', type=str, help='Validate specific file')
     parser.add_argument('--fuzzy', action='store_true', help='Check fuzzy entries')
     parser.add_argument('--ignore-empty', action='store_true', help='Ignore empty msgstr')
+    parser.add_argument('-t', '--check-trad', action='store_true',
+                        help='Check zh-TW locale consistency via orthographic heuristic (OpenCC)')
+    parser.add_argument('--trad-threshold', type=float, default=TRAD_CHECK_THRESHOLD,
+                        help=f'Orthographic variation threshold for locale consistency check (default: {TRAD_CHECK_THRESHOLD})')
     args = parser.parse_args()
     
     if args.fuzzy:
@@ -172,6 +231,13 @@ if __name__ == "__main__":
         
     if args.ignore_empty:
         ignore_empty = True
+
+    if args.check_trad:
+        if not args.file:
+            print("--check-trad requires -f <file>")
+            sys.exit(1)
+        check_trad_file(args.file, threshold=args.trad_threshold)
+        sys.exit(0)
 
     if args.all:
         sys.exit(validate_all())

--- a/translation-validator.py
+++ b/translation-validator.py
@@ -1,5 +1,5 @@
-#/usr/bin/env python3
-import os
+#!/usr/bin/env python3
+import functools
 import sys
 import glob
 import argparse
@@ -99,6 +99,30 @@ escape_table = str.maketrans(escape_chars)
 def escape_string(s) -> str:
     return s.translate(escape_table)
 
+@functools.lru_cache
+def load_template_msgid() -> set:
+    template_catalog = read_po(open("tl/template.pot", 'r', encoding='utf-8'))
+    return set([entry.id for entry in template_catalog])
+
+def check_is_latest_template(tl_catalog) -> bool:
+    """
+    Check if the translation file is the latest template
+    """
+    template_msgid = load_template_msgid()
+    success = True
+    
+    for msgid in template_msgid:
+        if msgid in tl_catalog:
+            continue
+            
+        if msgid == "":
+            continue
+
+        print(f"\tMissing msgid: '{escape_string(msgid)}'")
+        success = False
+        
+    return success
+
 def validate_file(file_path) -> int:
     ret_code = 0
     summary = Summary()
@@ -119,6 +143,12 @@ def validate_file(file_path) -> int:
             ret_code = 1
 
     summary.print_summary()
+    
+    if not check_is_latest_template(catalog):
+        print(f"Warning: {file_path} may not be the latest template")
+        print("Please update the translation file with the latest template")
+        print(f"\tmsgmerge -o {file_path}_merged.po {file_path} tl/template.pot")
+        ret_code = 1
 
     return ret_code
 


### PR DESCRIPTION
## Summary

This PR updates the Traditional Chinese (`zh-TW`) translation and improves the translation toolchain.

### Translation changes (`tl/zh-TW.po`)

- **Imported translations from inochi-creator v0_8** using `po_import.py` to fill in entries that were empty or incorrectly translated in nijigenerate's copy, while preserving the target file's formatting and comments.
- **Corrected mistranslations** introduced during import, including:
  - Entries where `msgid` and `msgstr` were clearly swapped (e.g. `Load from File` ↔ `儲存至檔案`, `Export Video` → `輸出失敗…`)
-  based on the [L10N TW glossary](https://hackmd.io/@l10n-tw/glossaries) and Normalize zh-TW translations to Traditional Chinese conventions.
- **Fixed numerous entries** that still contained untranslated English or clearly wrong text (e.g. `Auto Segmentation` was `文檔`, `New Project` was `關閉 專案`)


### Toolchain additions

- **`po_import.py`** — merges translations from one `.po` file into another without modifying formatting, comments, whitespace, or already-translated entries. Supports `--overwrite` and `--use-fuzzy` flags.
- **`translation-validator.py`** — updated from inochi-creator v0_8 (cherry-picked original commit to preserve history); added:
  - Detection of untranslated marker `U+E894` in `msgstr`
  - `--check-trad` flag: orthographic heuristic via OpenCC to flag entries that may not follow zh-TW conventions
- **`TRANSLATING.md`** — documented both new tools with usage examples

## Test plan

[x] Build and run nijigenerate with the updated `zh-TW.po`
[x] Run `python translation-validator.py -f tl/zh-TW.po --ignore-empty` — should report no `fmtstr` or `icon` errors
```
Total: 1152, translated rate: 597/1152 (51.82%)
```
[x] Run `python translation-validator.py -t -f tl/zh-TW.po` to confirm zh-TW locale consistency